### PR TITLE
add support for global filters

### DIFF
--- a/pydantic_resolve/resolver.py
+++ b/pydantic_resolve/resolver.py
@@ -36,6 +36,7 @@ class Resolver:
     def __init__(
             self,
             loader_filters: Optional[Dict[Any, Dict[str, Any]]] = None,
+            loader_global_filters: Optional[Dict[str, Any]] = None,
             loader_instances: Optional[Dict[Any, Any]] = None,
             ensure_type=False,
             context: Optional[Dict[str, Any]] = None):
@@ -46,6 +47,7 @@ class Resolver:
 
         # for dataloader which has class attributes, you can assign the value at here
         self.loader_filters = loader_filters or {}
+        self.loader_global_filters = loader_global_filters or {}
 
         # now you can pass your loader instance, Resolver will check `isinstance``
         if loader_instances and self._validate_loader_instance(loader_instances):
@@ -149,7 +151,10 @@ class Resolver:
                         # if extra transform provides
                         loader = Loader()
 
-                        filter_config = self.loader_filters.get(Loader, {})
+                        filter_config = {
+                            **self.loader_global_filters,
+                            **self.loader_filters.get(Loader, {})
+                        }
 
                         for field in util.get_class_field_annotations(Loader):
                         # >>> 2.1.1


### PR DESCRIPTION
Add a way to pass filters for all data loaders that are used on the returned model.
In my case, I have multiple models with multiple resolve fields that have to be translated by a provided user language. Translations are loaded from an external source. Without this feature, I would have to define a language filter for every single data loader used in a model which sounds like a lot of boilerplate.