### PR TITLE
feat: auto-add missing LoadBy FK fields with exclude=True in resolver…

### DIFF
--- a/pydantic_resolve/utils/subset.py
+++ b/pydantic_resolve/utils/subset.py
@@ -1,9 +1,34 @@
-from typing import Any, Literal
-from pydantic import BaseModel, create_model, model_validator
+from typing import Any, Literal, get_origin, get_args
+from pydantic import BaseModel, create_model, model_validator, Field
 import copy
 import pydantic_resolve.constant as const
 from pydantic_resolve.utils.expose import ExposeAs
 from pydantic_resolve.utils.collector import SendTo
+
+
+def _extract_loadby_fk_fields(namespace: dict[str, Any]) -> set[str]:
+    """
+    Extract FK field names referenced by LoadBy annotations.
+
+    This function scans the namespace's annotations for fields that use LoadBy
+    and extracts the FK field names they reference.
+
+    Returns:
+        Set of field names (e.g., {'user_id', 'order_id'}) that LoadBy references
+    """
+    from typing import Annotated
+    from pydantic_resolve.utils.er_diagram import LoaderInfo
+
+    annotations = namespace.get('__annotations__', {})
+    fk_fields = set()
+
+    for attr_name, attr_type in annotations.items():
+        if get_origin(attr_type) is Annotated:
+            for arg in get_args(attr_type):
+                if isinstance(arg, LoaderInfo):
+                    fk_fields.add(arg.field)
+
+    return fk_fields
 
 
 class SubsetConfig(BaseModel):
@@ -222,6 +247,25 @@ class SubsetMeta(type):
         field_definitions = {}
         field_definitions.update(field_infos)
         field_definitions.update(extra_fields)
+
+        # Auto-add missing LoadBy FK fields with exclude=True
+        # Only add fields that exist in the parent class
+        loadby_fk_fields = _extract_loadby_fk_fields(namespace)
+        all_defined_fields = set(subset_fields) | set(extra_fields.keys())
+        parent_field_names = set(parent_kls.model_fields.keys())
+
+        for fk_field in loadby_fk_fields:
+            if fk_field not in all_defined_fields:
+                if fk_field in parent_field_names:
+                    # Get field info from parent to preserve type
+                    parent_field = parent_kls.model_fields[fk_field]
+                    field_definitions[fk_field] = (parent_field.annotation, Field(default=None, exclude=True))
+                else:
+                    # FK field doesn't exist in parent class - raise error early
+                    raise ValueError(
+                        f'LoadBy references field "{fk_field}" which does not exist in parent class "{parent_kls.__name__}". '
+                        f'Available fields: {list(parent_field_names)}'
+                    )
 
         subset_class = create_model(
             name,

--- a/tests/er_diagram/test_er_diagram.py
+++ b/tests/er_diagram/test_er_diagram.py
@@ -206,11 +206,31 @@ class BizCase4(DefineSubset):
     user: Annotated[Optional[User], LoadBy('user_id')] = None
 
 @pytest.mark.asyncio
-async def test_resolver_factory_of_er_config_not_found():
+async def test_resolver_factory_of_er_config_auto_add_fk_field():
+    """Test that missing LoadBy FK fields are auto-added with exclude=True."""
     MyResolver = config_resolver('MyResolver', er_diagram=diagram)
+
+    # user_id is not in subset but should be auto-added
     d = BizCase4(id=1, user_id=1)
-    with pytest.raises(AttributeError):
-        await MyResolver().resolve(d)
+
+    # Verify user_id field exists and has correct value
+    assert hasattr(d, 'user_id')
+    assert d.user_id == 1
+
+    # Verify user_id is excluded from serialization
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert dumped == {'id': 1, 'user': None}
+
+    # Resolve should work correctly
+    d = await MyResolver().resolve(d)
+    assert d.user is not None
+    assert d.user.name == "a"
+
+    # After resolve, user_id should still be excluded
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert 'user' in dumped
 
 @ensure_subset(Biz)
 class BizCase5(BaseModel):
@@ -230,19 +250,13 @@ async def test_resolver_factory_with_permitive_annotation():
     # assert d.foos_in_str_x == ["foo1", "foo2"]
 
 
-class BizCase6(DefineSubset):
-    __pydantic_resolve_subset__ = (Biz, ['id', 'user_id'])
+def test_loadby_references_nonexistent_field():
+    """Test that LoadBy referencing a non-existent field raises ValueError at class definition time."""
+    with pytest.raises(ValueError) as excinfo:
+        class BizCase6(DefineSubset):
+            __pydantic_resolve_subset__ = (Biz, ['id', 'user_id'])
 
-    user: Annotated[Optional[User], LoadBy('user_id_0')] = None
+            user: Annotated[Optional[User], LoadBy('user_id_0')] = None
 
-@pytest.mark.asyncio
-async def test_resolver_factory_of_er_relationship_not_found():
-    MyResolver = config_resolver('MyResolver', er_diagram=diagram)
-    d = BizCase6(id=1, user_id=1)
-    expected = (
-        'Relationship from "<class \'tests.er_diagram.test_er_diagram.Biz\'>" to '
-        '"typing.Optional[tests.er_diagram.test_er_diagram.User]" using "user_id_0", biz: "None", not found'
-    )
-    with pytest.raises(AttributeError) as excinfo:
-        await MyResolver().resolve(d)
-    assert str(excinfo.value) == expected
+    assert 'LoadBy references field "user_id_0" which does not exist in parent class "Biz"' in str(excinfo.value)
+    assert 'Available fields:' in str(excinfo.value)

--- a/tests/er_diagram/test_er_diagram_inline.py
+++ b/tests/er_diagram/test_er_diagram_inline.py
@@ -175,11 +175,31 @@ class BizCase4(DefineSubset):
     user: Annotated[Optional[User], LoadBy('user_id')] = None
 
 @pytest.mark.asyncio
-async def test_resolver_factory_of_er_config_not_found():
+async def test_resolver_factory_of_er_config_auto_add_fk_field():
+    """Test that missing LoadBy FK fields are auto-added with exclude=True."""
     MyResolver = config_resolver('MyResolver', er_diagram=BASE_ENTITY.get_diagram())
+
+    # user_id is not in subset but should be auto-added
     d = BizCase4(id=1, user_id=1)
-    with pytest.raises(AttributeError):
-        await MyResolver().resolve(d)
+
+    # Verify user_id field exists and has correct value
+    assert hasattr(d, 'user_id')
+    assert d.user_id == 1
+
+    # Verify user_id is excluded from serialization
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert dumped == {'id': 1, 'user': None}
+
+    # Resolve should work correctly
+    d = await MyResolver().resolve(d)
+    assert d.user is not None
+    assert d.user.name == "a"
+
+    # After resolve, user_id should still be excluded
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert 'user' in dumped
 
 @ensure_subset(Biz)
 class BizCase5(BaseModel):

--- a/tests/er_diagram/test_er_diagram_inline_anno.py
+++ b/tests/er_diagram/test_er_diagram_inline_anno.py
@@ -178,11 +178,31 @@ class BizCase4(DefineSubset):
     user: Annotated[Optional[User], LoadBy('user_id')] = None
 
 @pytest.mark.asyncio
-async def test_resolver_factory_of_er_config_not_found():
+async def test_resolver_factory_of_er_config_auto_add_fk_field():
+    """Test that missing LoadBy FK fields are auto-added with exclude=True."""
     MyResolver = config_resolver('MyResolver', er_diagram=BASE_ENTITY.get_diagram())
+
+    # user_id is not in subset but should be auto-added
     d = BizCase4(id=1, user_id=1)
-    with pytest.raises(AttributeError):
-        await MyResolver().resolve(d)
+
+    # Verify user_id field exists and has correct value
+    assert hasattr(d, 'user_id')
+    assert d.user_id == 1
+
+    # Verify user_id is excluded from serialization
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert dumped == {'id': 1, 'user': None}
+
+    # Resolve should work correctly
+    d = await MyResolver().resolve(d)
+    assert d.user is not None
+    assert d.user.name == "a"
+
+    # After resolve, user_id should still be excluded
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert 'user' in dumped
 
 @ensure_subset(Biz)
 class BizCase5(BaseModel):

--- a/tests/er_diagram/test_er_diagram_inline_short.py
+++ b/tests/er_diagram/test_er_diagram_inline_short.py
@@ -175,11 +175,31 @@ class BizCase4(DefineSubset):
     user: Annotated[Optional[User], LoadBy('user_id')] = None
 
 @pytest.mark.asyncio
-async def test_resolver_factory_of_er_config_not_found():
+async def test_resolver_factory_of_er_config_auto_add_fk_field():
+    """Test that missing LoadBy FK fields are auto-added with exclude=True."""
     MyResolver = config_resolver('MyResolver', er_diagram=BASE_ENTITY.get_diagram())
+
+    # user_id is not in subset but should be auto-added
     d = BizCase4(id=1, user_id=1)
-    with pytest.raises(AttributeError):
-        await MyResolver().resolve(d)
+
+    # Verify user_id field exists and has correct value
+    assert hasattr(d, 'user_id')
+    assert d.user_id == 1
+
+    # Verify user_id is excluded from serialization
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert dumped == {'id': 1, 'user': None}
+
+    # Resolve should work correctly
+    d = await MyResolver().resolve(d)
+    assert d.user is not None
+    assert d.user.name == "a"
+
+    # After resolve, user_id should still be excluded
+    dumped = d.model_dump()
+    assert 'user_id' not in dumped
+    assert 'user' in dumped
 
 @ensure_subset(Biz)
 class BizCase5(BaseModel):


### PR DESCRIPTION
v3.1.1 (2026-3-18)

- feat:
    - **Auto-add missing LoadBy FK fields in DefineSubset**: When using `LoadBy` annotation in `DefineSubset`, the referenced FK field (e.g., `user_id` in `LoadBy('user_id')`) is now automatically added with `exclude=True` if not explicitly defined in the subset
    - **Early validation for invalid FK references**: If `LoadBy` references a field that doesn't exist in the parent class, a `ValueError` is raised at class definition time instead of during `resolve()`