### PR TITLE
fix: Replace type() factory with inheritance in empty loaders and copy_dataloader_kls

### DIFF
--- a/pydantic_resolve/utils/dataloader.py
+++ b/pydantic_resolve/utils/dataloader.py
@@ -34,7 +34,11 @@ def copy_dataloader_kls(name, loader_kls):
     SeniorMemberLoader = copy_dataloader('SeniorMemberLoader', ul.UserByLevelLoader)
     JuniorMemberLoader = copy_dataloader('JuniorMemberLoader', ul.UserByLevelLoader)
     """
-    return type(name, loader_kls.__bases__, dict(loader_kls.__dict__))
+    class NewLoader(loader_kls):
+        pass
+    NewLoader.__name__ = name
+    NewLoader.__qualname__ = name
+    return NewLoader
 
 
 class StrictEmptyLoader(DataLoader):
@@ -45,26 +49,36 @@ class StrictEmptyLoader(DataLoader):
 
 class ListEmptyLoader(DataLoader):
     async def batch_load_fn(self, keys):
-        dct = {}
-        return [dct.get(k, []) for k in keys]
+        return [[] for _ in keys]
 
 
 class SingleEmptyLoader(DataLoader):
     async def batch_load_fn(self, keys):
-        dct = {}
-        return [dct.get(k, None) for k in keys]
+        return [None for _ in keys]
 
 
 def generate_strict_empty_loader(name):
     """generated Loader will raise ValueError if not found"""
-    return type(name, StrictEmptyLoader.__bases__, dict(StrictEmptyLoader.__dict__))  #noqa
+    class NewLoader(StrictEmptyLoader):
+        pass
+    NewLoader.__name__ = name
+    NewLoader.__qualname__ = name
+    return NewLoader
 
 
 def generate_list_empty_loader(name):
     """generated Loader will return [] if not found"""
-    return type(name, ListEmptyLoader.__bases__, dict(ListEmptyLoader.__dict__))  #noqa
+    class NewLoader(ListEmptyLoader):
+        pass
+    NewLoader.__name__ = name
+    NewLoader.__qualname__ = name
+    return NewLoader
 
 
 def generate_single_empty_loader(name):
     """generated Loader will return None if not found"""
-    return type(name, SingleEmptyLoader.__bases__, dict(SingleEmptyLoader.__dict__))  #noqa
+    class NewLoader(SingleEmptyLoader):
+        pass
+    NewLoader.__name__ = name
+    NewLoader.__qualname__ = name
+    return NewLoader

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -133,8 +133,107 @@ def test_auto_mapper_4():
     class AA:
         def __init__(self, a):
             self.a = a
-    
+
     p1 = (A, AA(a=1))
     with pytest.raises(AttributeError):
         pydantic_resolve.utils.conversion._get_mapping_rule(*p1)(*p1)  # type: ignore
+
+
+# ---- EmptyLoader tests ----
+
+@pytest.mark.asyncio
+async def test_strict_empty_loader_raises():
+    from pydantic_resolve.utils.dataloader import StrictEmptyLoader
+    loader = StrictEmptyLoader()
+    with pytest.raises(ValueError, match='EmptyLoader should load from pre loaded data'):
+        await loader.batch_load_fn([1, 2])
+
+
+@pytest.mark.asyncio
+async def test_list_empty_loader():
+    from pydantic_resolve.utils.dataloader import ListEmptyLoader
+    loader = ListEmptyLoader()
+    result = await loader.batch_load_fn([1, 2, 3])
+    assert result == [[], [], []]
+
+
+@pytest.mark.asyncio
+async def test_single_empty_loader():
+    from pydantic_resolve.utils.dataloader import SingleEmptyLoader
+    loader = SingleEmptyLoader()
+    result = await loader.batch_load_fn([1, 2, 3])
+    assert result == [None, None, None]
+
+
+def test_generate_strict_empty_loader_creates_independent_class():
+    from pydantic_resolve.utils.dataloader import generate_strict_empty_loader
+    LoaderA = generate_strict_empty_loader('LoaderA')
+    LoaderB = generate_strict_empty_loader('LoaderB')
+    assert LoaderA.__name__ == 'LoaderA'
+    assert LoaderB.__name__ == 'LoaderB'
+    assert LoaderA is not LoaderB
+
+
+def test_generate_list_empty_loader_creates_independent_class():
+    from pydantic_resolve.utils.dataloader import generate_list_empty_loader
+    LoaderA = generate_list_empty_loader('LoaderA')
+    LoaderB = generate_list_empty_loader('LoaderB')
+    assert LoaderA.__name__ == 'LoaderA'
+    assert LoaderB.__name__ == 'LoaderB'
+    assert LoaderA is not LoaderB
+
+
+def test_generate_single_empty_loader_creates_independent_class():
+    from pydantic_resolve.utils.dataloader import generate_single_empty_loader
+    LoaderA = generate_single_empty_loader('LoaderA')
+    LoaderB = generate_single_empty_loader('LoaderB')
+    assert LoaderA.__name__ == 'LoaderA'
+    assert LoaderB.__name__ == 'LoaderB'
+    assert LoaderA is not LoaderB
+
+
+@pytest.mark.asyncio
+async def test_generated_loaders_have_independent_state():
+    """Verify that generated loaders don't share mutable class state."""
+    from pydantic_resolve.utils.dataloader import generate_list_empty_loader
+    LoaderA = generate_list_empty_loader('LoaderA')
+    LoaderB = generate_list_empty_loader('LoaderB')
+    # Mutate one class attribute
+    LoaderA.custom_attr = 'modified'
+    assert not hasattr(LoaderB, 'custom_attr')
+
+
+def test_copy_dataloader_kls_creates_independent_class():
+    from aiodataloader import DataLoader
+    from pydantic_resolve.utils.dataloader import copy_dataloader_kls
+
+    class MyLoader(DataLoader):
+        batch_size = 10
+        async def batch_load_fn(self, keys):
+            return keys
+
+    CopiedA = copy_dataloader_kls('CopiedA', MyLoader)
+    CopiedB = copy_dataloader_kls('CopiedB', MyLoader)
+
+    assert CopiedA.__name__ == 'CopiedA'
+    assert CopiedB.__name__ == 'CopiedB'
+    assert CopiedA is not CopiedB
+    assert CopiedA.batch_size == 10
+    assert CopiedB.batch_size == 10
+
+
+def test_copy_dataloader_kls_state_isolation():
+    from aiodataloader import DataLoader
+    from pydantic_resolve.utils.dataloader import copy_dataloader_kls
+
+    class MyLoader(DataLoader):
+        batch_size = 10
+        async def batch_load_fn(self, keys):
+            return keys
+
+    CopiedA = copy_dataloader_kls('CopiedA', MyLoader)
+    CopiedB = copy_dataloader_kls('CopiedB', MyLoader)
+
+    CopiedA.batch_size = 99
+    assert CopiedB.batch_size == 10
 


### PR DESCRIPTION
## Summary

- `copy_dataloader_kls` 和 `generate_*_empty_loader` 从 `type()` 改为继承模式，消除浅拷贝 `__dict__` 导致的可变状态共享风险
- 简化 `ListEmptyLoader` / `SingleEmptyLoader` 实现（同时 closes #265）
- 补充了 9 个测试，覆盖所有之前未测试的函数和类

Closes #266, Closes #265

## Test plan

- [x] 新增 9 个单元测试全部通过
- [x] 全量 696 测试通过
- [x] 状态隔离测试验证生成的类之间不共享可变状态