### PR TITLE
refactor: Merge M2O and R-O2O loader into shared _create_lookup_loader

### DIFF
--- a/pydantic_resolve/integration/django/loader.py
+++ b/pydantic_resolve/integration/django/loader.py
@@ -94,6 +94,52 @@ async def _evaluate_queryset(queryset: Any) -> list[Any]:
     return await sync_to_async(list, thread_sensitive=True)(queryset)
 
 
+def _create_lookup_loader(
+    *,
+    source_orm_kls: type,
+    rel_name: str,
+    target_orm_kls: type,
+    target_dto_kls: type,
+    target_field_name: str,
+    using: Any = None,
+    filters: list[Any] | None = None,
+    suffix: str,
+) -> type[DataLoader]:
+    """Shared implementation for M2O and R-O2O lookup loaders."""
+    identity = _build_loader_identity(source_orm_kls, rel_name, suffix)
+
+    class _Loader(DataLoader):
+        async def batch_load_fn(self, keys):
+            effective_fields = _get_effective_query_fields(
+                self,
+                self.target_dto_kls,
+                extra_fields=[self.target_field_name],
+            )
+            effective_fields = _sanitize_only_fields(self, self.target_orm_kls, effective_fields)
+
+            queryset = self.target_orm_kls.objects.filter(
+                **{f"{self.target_field_name}__in": list(set(keys))}
+            )
+            queryset = _maybe_use_database(queryset, self.using)
+            queryset = _apply_filters(queryset, self.filters)
+            queryset = _apply_only(queryset, effective_fields)
+            rows = await _evaluate_queryset(queryset)
+
+            lookup = {getattr(row, self.target_field_name): row for row in rows}
+            return [
+                lookup[key] if key in lookup else None
+                for key in keys
+            ]
+
+    _Loader.target_orm_kls = target_orm_kls
+    _Loader.target_dto_kls = target_dto_kls
+    _Loader.target_field_name = target_field_name
+    _Loader.using = staticmethod(using) if callable(using) else using
+    _Loader.filters = filters
+
+    return _finalize_loader_class(_Loader, identity)
+
+
 def create_many_to_one_loader(
     *,
     source_orm_kls: type,
@@ -104,38 +150,16 @@ def create_many_to_one_loader(
     using: Any = None,
     filters: list[Any] | None = None,
 ) -> type[DataLoader]:
-    identity = _build_loader_identity(source_orm_kls, rel_name, "M2O")
-
-    class _Loader(DataLoader):
-        async def batch_load_fn(self, keys):
-            effective_fields = _get_effective_query_fields(
-                self,
-                self.target_dto_kls,
-                extra_fields=[self.target_remote_field_name],
-            )
-            effective_fields = _sanitize_only_fields(self, self.target_orm_kls, effective_fields)
-
-            queryset = self.target_orm_kls.objects.filter(
-                **{f"{self.target_remote_field_name}__in": list(set(keys))}
-            )
-            queryset = _maybe_use_database(queryset, self.using)
-            queryset = _apply_filters(queryset, self.filters)
-            queryset = _apply_only(queryset, effective_fields)
-            rows = await _evaluate_queryset(queryset)
-
-            lookup = {getattr(row, self.target_remote_field_name): row for row in rows}
-            return [
-                lookup[key] if key in lookup else None
-                for key in keys
-            ]
-
-    _Loader.target_orm_kls = target_orm_kls
-    _Loader.target_dto_kls = target_dto_kls
-    _Loader.target_remote_field_name = target_remote_field_name
-    _Loader.using = staticmethod(using) if callable(using) else using
-    _Loader.filters = filters
-
-    return _finalize_loader_class(_Loader, identity)
+    return _create_lookup_loader(
+        source_orm_kls=source_orm_kls,
+        rel_name=rel_name,
+        target_orm_kls=target_orm_kls,
+        target_dto_kls=target_dto_kls,
+        target_field_name=target_remote_field_name,
+        using=using,
+        filters=filters,
+        suffix="M2O",
+    )
 
 
 def create_one_to_many_loader(
@@ -192,38 +216,16 @@ def create_reverse_one_to_one_loader(
     using: Any = None,
     filters: list[Any] | None = None,
 ) -> type[DataLoader]:
-    identity = _build_loader_identity(source_orm_kls, rel_name, "RO2O")
-
-    class _Loader(DataLoader):
-        async def batch_load_fn(self, keys):
-            effective_fields = _get_effective_query_fields(
-                self,
-                self.target_dto_kls,
-                extra_fields=[self.target_relation_field_name],
-            )
-            effective_fields = _sanitize_only_fields(self, self.target_orm_kls, effective_fields)
-
-            queryset = self.target_orm_kls.objects.filter(
-                **{f"{self.target_relation_field_name}__in": list(set(keys))}
-            )
-            queryset = _maybe_use_database(queryset, self.using)
-            queryset = _apply_filters(queryset, self.filters)
-            queryset = _apply_only(queryset, effective_fields)
-            rows = await _evaluate_queryset(queryset)
-
-            lookup = {getattr(row, self.target_relation_field_name): row for row in rows}
-            return [
-                lookup[key] if key in lookup else None
-                for key in keys
-            ]
-
-    _Loader.target_orm_kls = target_orm_kls
-    _Loader.target_dto_kls = target_dto_kls
-    _Loader.target_relation_field_name = target_relation_field_name
-    _Loader.using = staticmethod(using) if callable(using) else using
-    _Loader.filters = filters
-
-    return _finalize_loader_class(_Loader, identity)
+    return _create_lookup_loader(
+        source_orm_kls=source_orm_kls,
+        rel_name=rel_name,
+        target_orm_kls=target_orm_kls,
+        target_dto_kls=target_dto_kls,
+        target_field_name=target_relation_field_name,
+        using=using,
+        filters=filters,
+        suffix="RO2O",
+    )
 
 
 def create_many_to_many_loader(

--- a/pydantic_resolve/integration/sqlalchemy/loader.py
+++ b/pydantic_resolve/integration/sqlalchemy/loader.py
@@ -91,6 +91,55 @@ def _apply_load_only(
     return stmt
 
 
+def _create_lookup_loader(
+    *,
+    source_orm_kls: type,
+    rel_name: str,
+    target_orm_kls: type,
+    target_dto_kls: type,
+    target_col_name: str,
+    session_factory: Callable,
+    filters: list[Any] | None = None,
+    suffix: str,
+) -> type[DataLoader]:
+    """Shared implementation for M2O and R-O2O lookup loaders."""
+    class _Loader(DataLoader):
+        async def batch_load_fn(self, keys):
+            from sqlalchemy import select
+
+            effective_fields = _get_effective_query_fields(
+                self,
+                self.target_dto_kls,
+                extra_fields=[self.target_col_name],
+            )
+
+            async with self.session_factory() as session:
+                stmt = select(self.target_orm_kls)
+                stmt = _apply_load_only(stmt, self.target_orm_kls, effective_fields)
+                stmt = stmt.where(
+                    getattr(self.target_orm_kls, self.target_col_name).in_(keys)
+                )
+                stmt = _apply_filters(stmt, self.filters)
+                rows = (await session.scalars(stmt)).all()
+
+            lookup = {getattr(row, self.target_col_name): row for row in rows}
+            return [
+                lookup[k] if k in lookup else None
+                for k in keys
+            ]
+
+    _Loader.target_orm_kls = target_orm_kls
+    _Loader.target_dto_kls = target_dto_kls
+    _Loader.target_col_name = target_col_name
+    _Loader.session_factory = staticmethod(session_factory)
+    _Loader.filters = filters
+
+    return _finalize_loader_class(
+        _Loader,
+        _build_loader_identity(source_orm_kls, rel_name, suffix),
+    )
+
+
 def create_many_to_one_loader(
     *,
     source_orm_kls: type,
@@ -101,40 +150,15 @@ def create_many_to_one_loader(
     session_factory: Callable,
     filters: list[Any] | None = None,
 ) -> type[DataLoader]:
-    class _Loader(DataLoader):
-        async def batch_load_fn(self, keys):
-            from sqlalchemy import select
-
-            effective_fields = _get_effective_query_fields(
-                self,
-                self.target_dto_kls,
-                extra_fields=[self.target_remote_col_name],
-            )
-
-            async with self.session_factory() as session:
-                stmt = select(self.target_orm_kls)
-                stmt = _apply_load_only(stmt, self.target_orm_kls, effective_fields)
-                stmt = stmt.where(
-                    getattr(self.target_orm_kls, self.target_remote_col_name).in_(keys)
-                )
-                stmt = _apply_filters(stmt, self.filters)
-                rows = (await session.scalars(stmt)).all()
-
-            lookup = {getattr(row, self.target_remote_col_name): row for row in rows}
-            return [
-                lookup[k] if k in lookup else None
-                for k in keys
-            ]
-
-    _Loader.target_orm_kls = target_orm_kls
-    _Loader.target_dto_kls = target_dto_kls
-    _Loader.target_remote_col_name = target_remote_col_name
-    _Loader.session_factory = staticmethod(session_factory)
-    _Loader.filters = filters
-
-    return _finalize_loader_class(
-        _Loader,
-        _build_loader_identity(source_orm_kls, rel_name, "M2O"),
+    return _create_lookup_loader(
+        source_orm_kls=source_orm_kls,
+        rel_name=rel_name,
+        target_orm_kls=target_orm_kls,
+        target_dto_kls=target_dto_kls,
+        target_col_name=target_remote_col_name,
+        session_factory=session_factory,
+        filters=filters,
+        suffix="M2O",
     )
 
 
@@ -195,40 +219,15 @@ def create_reverse_one_to_one_loader(
     session_factory: Callable,
     filters: list[Any] | None = None,
 ) -> type[DataLoader]:
-    class _Loader(DataLoader):
-        async def batch_load_fn(self, keys):
-            from sqlalchemy import select
-
-            effective_fields = _get_effective_query_fields(
-                self,
-                self.target_dto_kls,
-                extra_fields=[self.target_fk_col_name],
-            )
-
-            async with self.session_factory() as session:
-                stmt = select(self.target_orm_kls)
-                stmt = _apply_load_only(stmt, self.target_orm_kls, effective_fields)
-                stmt = stmt.where(
-                    getattr(self.target_orm_kls, self.target_fk_col_name).in_(keys)
-                )
-                stmt = _apply_filters(stmt, self.filters)
-                rows = (await session.scalars(stmt)).all()
-
-            lookup = {getattr(row, self.target_fk_col_name): row for row in rows}
-            return [
-                lookup[k] if k in lookup else None
-                for k in keys
-            ]
-
-    _Loader.target_orm_kls = target_orm_kls
-    _Loader.target_dto_kls = target_dto_kls
-    _Loader.target_fk_col_name = target_fk_col_name
-    _Loader.session_factory = staticmethod(session_factory)
-    _Loader.filters = filters
-
-    return _finalize_loader_class(
-        _Loader,
-        _build_loader_identity(source_orm_kls, rel_name, "RO2O"),
+    return _create_lookup_loader(
+        source_orm_kls=source_orm_kls,
+        rel_name=rel_name,
+        target_orm_kls=target_orm_kls,
+        target_dto_kls=target_dto_kls,
+        target_col_name=target_fk_col_name,
+        session_factory=session_factory,
+        filters=filters,
+        suffix="RO2O",
     )
 
 

--- a/pydantic_resolve/integration/tortoise/loader.py
+++ b/pydantic_resolve/integration/tortoise/loader.py
@@ -91,6 +91,52 @@ def _apply_only(queryset: Any, fields: list[str]) -> Any:
     return queryset
 
 
+def _create_lookup_loader(
+    *,
+    source_orm_kls: type,
+    rel_name: str,
+    target_orm_kls: type,
+    target_dto_kls: type,
+    target_field_name: str,
+    using_db: Any = None,
+    filters: list[Any] | None = None,
+    suffix: str,
+) -> type[DataLoader]:
+    """Shared implementation for M2O and R-O2O lookup loaders."""
+    identity = _build_loader_identity(source_orm_kls, rel_name, suffix)
+
+    class _Loader(DataLoader):
+        async def batch_load_fn(self, keys):
+            effective_fields = _get_effective_query_fields(
+                self,
+                self.target_dto_kls,
+                extra_fields=[self.target_field_name],
+            )
+            effective_fields = _sanitize_only_fields(self, self.target_orm_kls, effective_fields)
+
+            queryset = self.target_orm_kls.filter(
+                **{f"{self.target_field_name}__in": list(set(keys))}
+            )
+            queryset = _maybe_use_db(queryset, self.using_db)
+            queryset = _apply_filters(queryset, self.filters)
+            queryset = _apply_only(queryset, effective_fields)
+            rows = await queryset
+
+            lookup = {getattr(row, self.target_field_name): row for row in rows}
+            return [
+                lookup[k] if k in lookup else None
+                for k in keys
+            ]
+
+    _Loader.target_orm_kls = target_orm_kls
+    _Loader.target_dto_kls = target_dto_kls
+    _Loader.target_field_name = target_field_name
+    _Loader.using_db = staticmethod(using_db) if callable(using_db) else using_db
+    _Loader.filters = filters
+
+    return _finalize_loader_class(_Loader, identity)
+
+
 def create_many_to_one_loader(
     *,
     source_orm_kls: type,
@@ -101,38 +147,16 @@ def create_many_to_one_loader(
     using_db: Any = None,
     filters: list[Any] | None = None,
 ) -> type[DataLoader]:
-    identity = _build_loader_identity(source_orm_kls, rel_name, "M2O")
-
-    class _Loader(DataLoader):
-        async def batch_load_fn(self, keys):
-            effective_fields = _get_effective_query_fields(
-                self,
-                self.target_dto_kls,
-                extra_fields=[self.target_remote_field_name],
-            )
-            effective_fields = _sanitize_only_fields(self, self.target_orm_kls, effective_fields)
-
-            queryset = self.target_orm_kls.filter(
-                **{f"{self.target_remote_field_name}__in": list(set(keys))}
-            )
-            queryset = _maybe_use_db(queryset, self.using_db)
-            queryset = _apply_filters(queryset, self.filters)
-            queryset = _apply_only(queryset, effective_fields)
-            rows = await queryset
-
-            lookup = {getattr(row, self.target_remote_field_name): row for row in rows}
-            return [
-                lookup[k] if k in lookup else None
-                for k in keys
-            ]
-
-    _Loader.target_orm_kls = target_orm_kls
-    _Loader.target_dto_kls = target_dto_kls
-    _Loader.target_remote_field_name = target_remote_field_name
-    _Loader.using_db = staticmethod(using_db) if callable(using_db) else using_db
-    _Loader.filters = filters
-
-    return _finalize_loader_class(_Loader, identity)
+    return _create_lookup_loader(
+        source_orm_kls=source_orm_kls,
+        rel_name=rel_name,
+        target_orm_kls=target_orm_kls,
+        target_dto_kls=target_dto_kls,
+        target_field_name=target_remote_field_name,
+        using_db=using_db,
+        filters=filters,
+        suffix="M2O",
+    )
 
 
 def create_one_to_many_loader(
@@ -189,38 +213,16 @@ def create_reverse_one_to_one_loader(
     using_db: Any = None,
     filters: list[Any] | None = None,
 ) -> type[DataLoader]:
-    identity = _build_loader_identity(source_orm_kls, rel_name, "RO2O")
-
-    class _Loader(DataLoader):
-        async def batch_load_fn(self, keys):
-            effective_fields = _get_effective_query_fields(
-                self,
-                self.target_dto_kls,
-                extra_fields=[self.target_relation_field_name],
-            )
-            effective_fields = _sanitize_only_fields(self, self.target_orm_kls, effective_fields)
-
-            queryset = self.target_orm_kls.filter(
-                **{f"{self.target_relation_field_name}__in": list(set(keys))}
-            )
-            queryset = _maybe_use_db(queryset, self.using_db)
-            queryset = _apply_filters(queryset, self.filters)
-            queryset = _apply_only(queryset, effective_fields)
-            rows = await queryset
-
-            lookup = {getattr(row, self.target_relation_field_name): row for row in rows}
-            return [
-                lookup[k] if k in lookup else None
-                for k in keys
-            ]
-
-    _Loader.target_orm_kls = target_orm_kls
-    _Loader.target_dto_kls = target_dto_kls
-    _Loader.target_relation_field_name = target_relation_field_name
-    _Loader.using_db = staticmethod(using_db) if callable(using_db) else using_db
-    _Loader.filters = filters
-
-    return _finalize_loader_class(_Loader, identity)
+    return _create_lookup_loader(
+        source_orm_kls=source_orm_kls,
+        rel_name=rel_name,
+        target_orm_kls=target_orm_kls,
+        target_dto_kls=target_dto_kls,
+        target_field_name=target_relation_field_name,
+        using_db=using_db,
+        filters=filters,
+        suffix="RO2O",
+    )
 
 
 def create_many_to_many_loader(


### PR DESCRIPTION
## Summary

- SQLAlchemy、Django、Tortoise 三个框架中 `create_many_to_one_loader` 和 `create_reverse_one_to_one_loader` 的 `batch_load_fn` 逻辑完全一致（都是 where + lookup），提取为内部 `_create_lookup_loader` 函数
- 公共 API 签名不变，仅内部实现去重
- 减少约 130 行重复代码

Closes #268

## Test plan

- [x] 全量 696 测试通过
- [x] SQLAlchemy: M2O + R-O2O 均有测试覆盖
- [x] Django: M2O + R-O2O 均有测试覆盖
- [x] Tortoise: M2O 有测试覆盖