### PR TITLE
fix(resolver): isolate per-call state and guard against concurrent resolve() (#289)

### DIFF
--- a/docs/api_resolver.md
+++ b/docs/api_resolver.md
@@ -65,6 +65,35 @@ result = await Resolver(split_loader_by_type=True).resolve(Dashboard(id=1))
 
 **Incompatible with `loader_instances`:** Pre-created instances are shared by nature and cannot be split per type. Raises `ValueError` if both are provided.
 
+### Concurrency and reuse
+
+A `Resolver` instance is **not safe for concurrent `resolve()` calls**. Per-call state (scanned metadata, loader cache, collector alias map) lives on the instance, so two overlapping calls would clobber each other.
+
+```python
+resolver = Resolver()
+
+# OK: sequential reuse — the second call starts after the first returns
+await resolver.resolve(tree_a)
+await resolver.resolve(tree_b)
+
+# BAD: overlapping calls on the same instance — raises RuntimeError
+await asyncio.gather(
+    resolver.resolve(tree_a),
+    resolver.resolve(tree_b),
+)
+```
+
+If you need concurrency, create a separate `Resolver()` per task:
+
+```python
+await asyncio.gather(
+    Resolver().resolve(tree_a),
+    Resolver().resolve(tree_b),
+)
+```
+
+In request handlers (FastAPI, Starlette, …), build a fresh `Resolver()` per request rather than sharing a module-level singleton — both for this rule and so DataLoader batches stay scoped to a single request. The runtime will raise `RuntimeError` with a clear message if it detects overlap, converting an otherwise cryptic `KeyError` into an actionable error.
+
 ### resolve()
 
 ```python

--- a/docs/api_resolver.zh.md
+++ b/docs/api_resolver.zh.md
@@ -65,6 +65,35 @@ result = await Resolver(split_loader_by_type=True).resolve(Dashboard(id=1))
 
 **与 `loader_instances` 不兼容：** 预创建的实例本质上是共享的，无法按类型分裂。同时传入会抛出 `ValueError`。
 
+### 并发与复用
+
+`Resolver` 实例**不支持并发的 `resolve()` 调用**。每次调用的状态（扫描得到的 metadata、loader 缓存、collector alias map）都挂在实例上，两个重叠的调用会互相覆写。
+
+```python
+resolver = Resolver()
+
+# OK：顺序复用 —— 第二次调用在第一次返回后才开始
+await resolver.resolve(tree_a)
+await resolver.resolve(tree_b)
+
+# 错误：同一实例上重叠调用 —— 抛出 RuntimeError
+await asyncio.gather(
+    resolver.resolve(tree_a),
+    resolver.resolve(tree_b),
+)
+```
+
+需要并发时，给每个任务新建 `Resolver()`：
+
+```python
+await asyncio.gather(
+    Resolver().resolve(tree_a),
+    Resolver().resolve(tree_b),
+)
+```
+
+在请求处理器里（FastAPI、Starlette 等），**每请求新建一个 `Resolver()`**，不要复用模块级 singleton——既是为了遵守本规则，也是为了让 DataLoader 的批量范围始终限定在单次请求内。运行时如果检测到重叠调用，会抛出 `RuntimeError` 并附明确指引，把原本难以诊断的 `KeyError` 转成可操作的错误。
+
 ### resolve()
 
 ```python

--- a/docs/fastapi_integration.md
+++ b/docs/fastapi_integration.md
@@ -199,7 +199,7 @@ async def create_task(data: TaskCreate):
 
 ## Performance
 
-1.  **One `Resolver()` per request.** The resolver creates fresh DataLoader instances each time, so batches are scoped correctly.
+1.  **One `Resolver()` per request.** The resolver creates fresh DataLoader instances each time, so batches are scoped correctly. Do not share a single `Resolver` across concurrent requests — `Resolver` is not safe for concurrent `resolve()` calls and will raise `RuntimeError` if it detects overlap (see [Resolver API · Concurrency and reuse](./api_resolver.md#concurrency-and-reuse)).
 
 2.  **Resolve the full list at once.** Don't resolve inside loops:
 

--- a/docs/fastapi_integration.zh.md
+++ b/docs/fastapi_integration.zh.md
@@ -197,7 +197,7 @@ async def create_task(data: TaskCreate):
 
 ## 性能
 
-1.  **每个请求一个 `Resolver()`。** resolver 每次都创建新的 DataLoader 实例，因此批次范围正确。
+1.  **每个请求一个 `Resolver()`。** resolver 每次都创建新的 DataLoader 实例，因此批次范围正确。不要在并发请求间复用同一个 `Resolver` —— `Resolver` 不支持并发的 `resolve()` 调用，运行时检测到重叠会抛出 `RuntimeError`（详见 [Resolver API · 并发与复用](./api_resolver.zh.md#并发与复用)）。
 
 2.  **一次性解析整个列表。** 不要在循环内逐项解析：
 

--- a/pydantic_resolve/resolver.py
+++ b/pydantic_resolve/resolver.py
@@ -172,10 +172,13 @@ class Resolver:
         for item in items:
             if analysis.is_acceptable_instance(item):
                 kls = item.__class__
+                kls_path = cache.get(kls)
+                if kls_path is None:
+                    kls_path = class_util.get_kls_full_name(kls)
                 nodes.append(_Node(
                     node=item,
                     kls=kls,
-                    kls_path=cache.get(kls, class_util.get_kls_full_name(kls)),
+                    kls_path=kls_path,
                     parent=parent,
                     ancestor_context=ancestor_context,
                 ))
@@ -203,16 +206,22 @@ class Resolver:
             for item in val:
                 if analysis.is_acceptable_instance(item):
                     kls = item.__class__
+                    kls_path = cache.get(kls)
+                    if kls_path is None:
+                        kls_path = class_util.get_kls_full_name(kls)
                     children.append(_Node(
                         node=item, kls=kls,
-                        kls_path=cache.get(kls, class_util.get_kls_full_name(kls)),
+                        kls_path=kls_path,
                         parent=parent, ancestor_context=ancestor_context,
                     ))
         elif analysis.is_acceptable_instance(val):
             kls = val.__class__
+            kls_path = cache.get(kls)
+            if kls_path is None:
+                kls_path = class_util.get_kls_full_name(kls)
             children.append(_Node(
                 node=val, kls=kls,
-                kls_path=cache.get(kls, class_util.get_kls_full_name(kls)),
+                kls_path=kls_path,
                 parent=parent, ancestor_context=ancestor_context,
             ))
         return children
@@ -528,43 +537,59 @@ class Resolver:
         if isinstance(node, list) and node == []:
             return node
 
-        # by default pydantic-resolve will deduce the root class from input node
-        # but in some scenario like Union types, it is unable to deduce the root class
-        # so user can provide the root class by annotation parameter
-        root_class = self.annotation if self.annotation else class_util.get_class_of_object(node)
-        resolver_class_id = id(self.__class__)
-
-        # Check cache with resolver_class_id for isolation between different resolver configurations
-        cached_metadata = _get_metadata_from_cache(resolver_class_id, root_class)
-        if cached_metadata:
-            self.metadata = cached_metadata
-        else:
-            metadata = analysis.convert_metadata_key_as_kls(
-                analysis.Analytic(
-                    er_pre_generator=getattr(self, const.ER_DIAGRAM_PRE_GENERATOR)
-                ).scan(root_class)
+        # Resolver is NOT reentrant: per-call state lives on self.
+        if getattr(self, '_in_resolve', False):
+            raise RuntimeError(
+                'Resolver.resolve() is already running on this instance. '
+                'A Resolver cannot be shared across concurrent resolve() calls — '
+                'create a fresh Resolver per call.'
             )
-            _set_metadata_to_cache(resolver_class_id, root_class, metadata)
-            self.metadata = metadata
+        self._in_resolve = True
 
-        self.loader_instance_cache = pydantic_resolve.loader_manager.validate_and_create_loader_instance(
-            self.loader_params,
-            self.global_loader_param,
-            self.loader_instances,
-            self.metadata,
-            self.context,
-            split_loader_by_type=self.split_loader_by_type)
+        # Reset per-call state so a Resolver instance can be awaited across
+        # independent trees without leaking collector alias maps from a prior run.
+        self.object_level_collect_alias_map_store = {}
 
-        has_context = analysis.has_context(self.metadata)
-        if has_context and self.context is None:
-            raise AttributeError('context is missing')
+        try:
+            # by default pydantic-resolve will deduce the root class from input node
+            # but in some scenario like Union types, it is unable to deduce the root class
+            # so user can provide the root class by annotation parameter
+            root_class = self.annotation if self.annotation else class_util.get_class_of_object(node)
+            resolver_class_id = id(self.__class__)
 
-        # Build kls → kls_path cache from metadata
-        self._kls_path_cache = {kls: meta['kls_path'] for kls, meta in self.metadata.items()}
+            # Check cache with resolver_class_id for isolation between different resolver configurations
+            cached_metadata = _get_metadata_from_cache(resolver_class_id, root_class)
+            if cached_metadata:
+                self.metadata = cached_metadata
+            else:
+                metadata = analysis.convert_metadata_key_as_kls(
+                    analysis.Analytic(
+                        er_pre_generator=getattr(self, const.ER_DIAGRAM_PRE_GENERATOR)
+                    ).scan(root_class)
+                )
+                _set_metadata_to_cache(resolver_class_id, root_class, metadata)
+                self.metadata = metadata
 
-        await self._traverse(node)
+            self.loader_instance_cache = pydantic_resolve.loader_manager.validate_and_create_loader_instance(
+                self.loader_params,
+                self.global_loader_param,
+                self.loader_instances,
+                self.metadata,
+                self.context,
+                split_loader_by_type=self.split_loader_by_type)
 
-        if self.debug:
-            self.performance.report()
+            has_context = analysis.has_context(self.metadata)
+            if has_context and self.context is None:
+                raise AttributeError('context is missing')
 
-        return node
+            # Build kls → kls_path cache from metadata
+            self._kls_path_cache = {kls: meta['kls_path'] for kls, meta in self.metadata.items()}
+
+            await self._traverse(node)
+
+            if self.debug:
+                self.performance.report()
+
+            return node
+        finally:
+            self._in_resolve = False

--- a/pydantic_resolve/resolver.py
+++ b/pydantic_resolve/resolver.py
@@ -58,6 +58,37 @@ def _set_metadata_to_cache(resolver_class_id: int, root_class: type, metadata) -
 
 
 class Resolver:
+    """Walks a Pydantic model tree, executes resolve_* / post_* methods,
+    and manages DataLoader batching.
+
+    Usage semantics
+    ---------------
+    * One ``Resolver`` instance per ``resolve()`` call is the recommended
+      pattern. Inside a request handler, build a fresh ``Resolver()`` and
+      await ``resolve()`` once.
+
+    * Sequential reuse on the same instance is supported::
+
+          resolver = Resolver()
+          await resolver.resolve(tree_a)
+          await resolver.resolve(tree_b)   # OK — runs after tree_a returns
+
+    * Concurrent ``resolve()`` calls on the same instance are NOT
+      supported. ``Resolver`` stores per-call state (metadata, loader
+      cache, collector alias map) on ``self``, so two overlapping
+      ``await`` calls would clobber each other::
+
+          # BAD — second call raises RuntimeError
+          await asyncio.gather(
+              resolver.resolve(tree_a),
+              resolver.resolve(tree_b),
+          )
+
+      The guard inside ``resolve()`` turns the otherwise cryptic
+      ``KeyError`` into a clear ``RuntimeError`` pointing you at the
+      fix. Create a separate ``Resolver()`` per concurrent call.
+    """
+
     # define class attribute using constant to avoid hardcoded name
     locals()[const.ER_DIAGRAM] = None
     locals()[const.ER_DIAGRAM_PRE_GENERATOR] = None


### PR DESCRIPTION
Resolves #289.

## Summary

Three independent issues with `Resolver` instance state, all fixed in `pydantic_resolve/resolver.py`:

### 1. `object_level_collect_alias_map_store` never reset between `resolve()` calls

The store was initialized once in `__init__` and only ever appended to in `_phase_b_prepare_collectors` (`id(bn.node) -> alias_map`). Consecutive `await resolver.resolve(tree_a)` / `await resolver.resolve(tree_b)` on the same instance accumulated entries indefinitely, and were vulnerable to stale reads if Python recycled an `id()` after GC.

**Repro:**
```
[run 1] store size = 1
[run 2] store size = 2   # FAIL — should be 1
```

### 2. Concurrent `resolve()` calls on the same instance clobber `self.metadata`

`self.metadata`, `self.loader_instance_cache`, `self._kls_path_cache`, and `object_level_collect_alias_map_store` are all written per-call as instance attributes. `asyncio.gather(resolver.resolve(a), resolver.resolve(b))` produced a cryptic `KeyError: 'resolve_params'` when task B overwrote `self.metadata` while task A was awaiting a loader.

**Repro:** two-schema gather → `KeyError: 'resolve_params'` at `analysis.py:797`.

### 3. `dict.get(k, expensive_default)` eagerly evaluated the default

In `_make_nodes` and `_collect_children`:
```python
kls_path=cache.get(kls, class_util.get_kls_full_name(kls))
```
The default argument is evaluated eagerly, so `get_kls_full_name` was called once per child node even on cache hit. Resolving 50 leaves triggered **55 calls** instead of **4**.

## Changes

- **Sub 1 + 2 (combined):** Added `_in_resolve` guard with `try/finally` in `resolve()`. Detects reentry and raises a clear `RuntimeError` directing the user at the fresh-Resolver-per-call pattern. Also resets `object_level_collect_alias_map_store` at entry.
- **Sub 3:** Replaced `cache.get(k, expensive_default)` with explicit `None` check in `_make_nodes` and `_collect_children`.

Sub 2 is fixed via **guard + raise**, not via making `Resolver` truly reentrant. Making it reentrant requires moving `self.metadata` and friends off `self` into a per-call context dataclass — that's a larger refactor touching ~15 method signatures, so it's tracked separately. The guard converts the cryptic `KeyError` into an actionable error.

## Test plan

- [x] Minimal repros for all three sub-issues written and run before/after the fix (output captured in this PR description's comments).
- [x] `pytest tests/` — **773 passed, 1 skipped** (no regression).
- [ ] Manual smoke test in a FastAPI singleton scenario (long-lived Resolver).

🤖 Generated with [Claude Code](https://claude.com/claude-code)