### PR TITLE
fix(profile): pop timer id in end() to stop timeset leak (#290)

### DIFF
--- a/pydantic_resolve/utils/profile.py
+++ b/pydantic_resolve/utils/profile.py
@@ -43,7 +43,7 @@ class Timer():
         return id
     
     def end(self, id: str):
-        start = self.timeset[id]
+        start = self.timeset.pop(id)
         t = self.to_ms(time.time() - start)
 
         self.records.append(t)


### PR DESCRIPTION
Resolves #290.

## Summary

One-line fix: ``Timer.end()`` was reading ``self.timeset[id]`` without removing it, so every debug-mode resolve() pair accumulated an entry. A long-lived ``Resolver(debug=True)`` (or any process that creates many Resolvers over time) leaked memory proportional to the number of timed method calls.

## Change

\`\`\`diff
 def end(self, id: str):
-    start = self.timeset[id]
+    start = self.timeset.pop(id)
     t = self.to_ms(time.time() - start)
     ...
\`\`\`

``start()`` and ``end()`` are always paired (finally block in resolver.py), so the dict is now empty between resolve() calls. No semantic change.

## Verification

Minimal repro — 5 consecutive resolve() calls on the same ``Resolver(debug=True)``, summed ``timeset`` sizes across all timers:

| | Before | After |
|---|---|---|
| run 1 | 12 | 0 |
| run 2 | 24 | 0 |
| run 3 | 36 | 0 |
| run 4 | 48 | 0 |
| run 5 | 60 | 0 |
| | grows linearly | stable |

## Test plan

- [x] Repro confirms leak before, stable after.
- [x] \`pytest tests/\` — **773 passed, 1 skipped**.
- [x] \`ruff check pydantic_resolve/utils/profile.py\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)