### PR TITLE
fix(resolver): reject empty context dict up-front (#291)

### DIFF
--- a/docs/api_resolver.md
+++ b/docs/api_resolver.md
@@ -31,7 +31,7 @@ class Resolver:
 | `loader_params` | `dict \| None` | `None` | Per-loader configuration keyed by loader class |
 | `global_loader_param` | `dict \| None` | `None` | Parameters applied to all loaders |
 | `loader_instances` | `dict \| None` | `None` | Pre-created DataLoader instances |
-| `context` | `dict \| None` | `None` | Global context dict accessible in all methods |
+| `context` | `dict \| None` | `None` | Global context dict accessible in all methods. Must be non-empty when provided — an empty dict raises `ValueError`; pass `None` (or omit) if no context is needed. |
 | `ensure_type` | `bool` | `False` | Validate return values match field type annotations |
 | `debug` | `bool` | `False` | Print per-node timing information |
 | `enable_from_attribute_in_type_adapter` | `bool` | `False` | Enable Pydantic v2 `from_attributes` mode |

--- a/docs/api_resolver.zh.md
+++ b/docs/api_resolver.zh.md
@@ -31,7 +31,7 @@ class Resolver:
 | `loader_params` | `dict \| None` | `None` | 按 loader 类键入的各个 loader 配置 |
 | `global_loader_param` | `dict \| None` | `None` | 应用于所有 loader 的参数 |
 | `loader_instances` | `dict \| None` | `None` | 预创建的 DataLoader 实例 |
-| `context` | `dict \| None` | `None` | 可在所有方法中访问的全局上下文字典 |
+| `context` | `dict \| None` | `None` | 可在所有方法中访问的全局上下文字典。传入时必须为非空 dict —— 空 dict 会抛 `ValueError`；如不需要 context 请传 `None`（或省略）。 |
 | `ensure_type` | `bool` | `False` | 验证返回值是否匹配字段类型注解 |
 | `debug` | `bool` | `False` | 打印每个节点的计时信息 |
 | `enable_from_attribute_in_type_adapter` | `bool` | `False` | 启用 Pydantic v2 的 `from_attributes` 模式 |

--- a/pydantic_resolve/resolver.py
+++ b/pydantic_resolve/resolver.py
@@ -145,11 +145,15 @@ class Resolver:
             or os.getenv("PYDANTIC_RESOLVE_ENABLE_FROM_ATTRIBUTE", "false").lower() == "true"
 
         self.ensure_type = ensure_type
-        if context is not None and not context:
-            raise ValueError(
-                'context must be a non-empty dict when provided. '
-                'Pass None (or omit the parameter) if no context is needed.'
-            )
+        if context is not None:
+            if not isinstance(context, dict):
+                raise TypeError(
+                    f'context must be a dict, got {type(context).__name__}.'
+                )
+            if not context:
+                raise ValueError(
+                    'context must be a non-empty dict, or None/omitted if no context is needed.'
+                )
         self.context = MappingProxyType(context) if context else None
         self.metadata = {}
         self.object_level_collect_alias_map_store: dict[int, dict] = {}

--- a/pydantic_resolve/resolver.py
+++ b/pydantic_resolve/resolver.py
@@ -145,6 +145,11 @@ class Resolver:
             or os.getenv("PYDANTIC_RESOLVE_ENABLE_FROM_ATTRIBUTE", "false").lower() == "true"
 
         self.ensure_type = ensure_type
+        if context is not None and not context:
+            raise ValueError(
+                'context must be a non-empty dict when provided. '
+                'Pass None (or omit the parameter) if no context is needed.'
+            )
         self.context = MappingProxyType(context) if context else None
         self.metadata = {}
         self.object_level_collect_alias_map_store: dict[int, dict] = {}

--- a/tests/resolver/test_27_context.py
+++ b/tests/resolver/test_27_context.py
@@ -83,8 +83,16 @@ def test_6_empty_context_dict_rejected():
         Resolver(context={})
 
 
-def test_7_none_context_still_allowed():
+@pytest.mark.parametrize('bad', [[1, 2, 3], ('a', 'b'), 'string', 42, object()])
+def test_7_non_dict_context_rejected(bad):
+    """Non-dict context values are rejected with TypeError at __init__,
+    rather than slipping through to MappingProxyType's opaque TypeError."""
+    with pytest.raises(TypeError, match='context must be a dict'):
+        Resolver(context=bad)
+
+
+def test_8_none_context_still_allowed():
     """Resolver() and Resolver(context=None) must remain valid — the rejection
-    only targets the nonsensical empty-dict case."""
+    only targets the nonsensical empty-dict / wrong-type cases."""
     assert Resolver().context is None
     assert Resolver(context=None).context is None

--- a/tests/resolver/test_27_context.py
+++ b/tests/resolver/test_27_context.py
@@ -70,3 +70,21 @@ async def test_5():
     earth = EarthBad2()
     with pytest.raises(TypeError):
         await Resolver(context={'count': 10}).resolve(earth)
+
+
+def test_6_empty_context_dict_rejected():
+    """Resolver(context={}) is rejected up-front rather than silently coerced to None.
+
+    See #291: previously the empty dict was falsy so self.context became None,
+    and the user only found out later via the unrelated `AttributeError:
+    context is missing` from the has_context check.
+    """
+    with pytest.raises(ValueError, match='context must be a non-empty dict'):
+        Resolver(context={})
+
+
+def test_7_none_context_still_allowed():
+    """Resolver() and Resolver(context=None) must remain valid — the rejection
+    only targets the nonsensical empty-dict case."""
+    assert Resolver().context is None
+    assert Resolver(context=None).context is None


### PR DESCRIPTION
Resolves #291.

## Summary

``Resolver.__init__`` used ``MappingProxyType(context) if context else None``, which silently coerced ``Resolver(context={})`` to ``self.context = None``. The user only discovered the loss later via the unrelated ``AttributeError: context is missing`` from the ``has_context`` check in ``resolve()`` — a misleading error that pointed at the wrong place.

An empty context dict has no defensible meaning (Resolver never lets you populate it later, and any method declaring a ``context`` parameter needs real keys), so the fix is to **reject it up-front** rather than silently accept it.

## Behavior change (breaking for the nonsensical case)

| Call | Before | After |
|---|---|---|
| ``Resolver()`` | OK, context = None | OK, context = None |
| ``Resolver(context=None)`` | OK, context = None | OK, context = None |
| ``Resolver(context={'user_id': 1})`` | OK | OK |
| ``Resolver(context={})`` | silently → None, fails later with misleading ``AttributeError`` | raises ``ValueError`` immediately |

The pre-existing ``has_context and self.context is None`` check in ``resolve()`` is kept — it covers a different scenario (a method declares ``context`` but the user passed nothing to Resolver).

## Changes

- ``pydantic_resolve/resolver.py``: 5-line guard in ``__init__``.
- ``tests/resolver/test_27_context.py``: 2 new cases — empty dict rejected, ``None`` still allowed.
- ``docs/api_resolver.md`` / ``docs/api_resolver.zh.md``: parameter table updated to document the non-empty constraint.

## Test plan

- [x] New cases pass; existing 5 context tests still pass.
- [x] \`pytest tests/\` — **775 passed, 1 skipped** (was 773 + 2 new).
- [x] \`ruff check\` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)