### PR TITLE
docs(seo): add per-page meta descriptions to all 62 doc pages

### DIFF
--- a/docs/api_cross_layer.md
+++ b/docs/api_cross_layer.md
@@ -1,3 +1,7 @@
+---
+description: API reference for ExposeAs, SendTo, and Collector — the cross-layer annotations that move values between ancestors and descendants in a resolve tree without hard-coded class references.
+---
+
 # Cross-Layer Annotations
 
 [中文版](./api_cross_layer.zh.md)

--- a/docs/api_cross_layer.zh.md
+++ b/docs/api_cross_layer.zh.md
@@ -1,3 +1,7 @@
+---
+description: ExposeAs、SendTo、Collector 的 API 参考——在 resolve 树中跨层移动值的注解，类与类之间无需硬编码引用。
+---
+
 # 跨层注解
 
 [English](./api_cross_layer.md)

--- a/docs/api_dataloader.md
+++ b/docs/api_dataloader.md
@@ -1,3 +1,7 @@
+---
+description: API reference for the DataLoader utilities — Loader (declare a loader dependency in resolve_* signatures), build_object, and build_list for batch-fetching and mapping results back to requesting keys.
+---
+
 # DataLoader Utilities
 
 [中文版](./api_dataloader.zh.md)

--- a/docs/api_dataloader.zh.md
+++ b/docs/api_dataloader.zh.md
@@ -1,3 +1,7 @@
+---
+description: Loader、build_object、build_list 的 API 参考——DataLoader 工具集，在 resolve_* 签名里声明依赖、批量拉取并把结果映射回请求 key。
+---
+
 # DataLoader 工具
 
 [English](./api_dataloader.md)

--- a/docs/api_erd.md
+++ b/docs/api_erd.md
@@ -1,3 +1,7 @@
+---
+description: API reference for base_entity, Relationship, and ErDiagram — the ERD primitives that centralize relationship declarations as executable, loader-bound definitions shared across REST, GraphQL, and MCP consumers.
+---
+
 # ER Diagram API
 
 [中文版](./api_erd.zh.md)

--- a/docs/api_erd.zh.md
+++ b/docs/api_erd.zh.md
@@ -1,3 +1,7 @@
+---
+description: base_entity、Relationship、ErDiagram 的 API 参考——把关系声明收敛为可执行、绑定 loader 的 ERD 原语，被 REST、GraphQL、MCP 消费者共享。
+---
+
 # ER 图 API
 
 [English](./api_erd.md)

--- a/docs/api_graphql.md
+++ b/docs/api_graphql.md
@@ -1,3 +1,7 @@
+---
+description: API reference for GraphQLHandler — execute GraphQL queries against your ERD with optional pagination and from-attribute type adaptation. Same Resolver engine and DataLoader batching as the REST side.
+---
+
 # GraphQL API
 
 [中文版](./api_graphql.zh.md)

--- a/docs/api_graphql.zh.md
+++ b/docs/api_graphql.zh.md
@@ -1,3 +1,7 @@
+---
+description: GraphQLHandler 的 API 参考——对 ERD 执行 GraphQL 查询，支持可选分页和 from-attribute 类型适配。底层与 REST 侧共用同一套 Resolver 和 DataLoader。
+---
+
 # GraphQL API
 
 [English](./api_graphql.md)

--- a/docs/api_mcp.md
+++ b/docs/api_mcp.md
@@ -1,3 +1,7 @@
+---
+description: API reference for create_mcp_server and AppConfig — build a FastMCP server from your ERD apps, exposing GraphQL queries to AI agents via the Model Context Protocol.
+---
+
 # MCP API
 
 [中文版](./api_mcp.zh.md)

--- a/docs/api_mcp.zh.md
+++ b/docs/api_mcp.zh.md
@@ -1,3 +1,7 @@
+---
+description: create_mcp_server 和 AppConfig 的 API 参考——从 ERD 应用构建 FastMCP 服务，把 GraphQL 查询通过 Model Context Protocol 暴露给 AI Agent。
+---
+
 # MCP API
 
 [English](./api_mcp.md)

--- a/docs/api_resolver.md
+++ b/docs/api_resolver.md
@@ -1,3 +1,7 @@
+---
+description: API reference for Resolver — the main entry point that walks a Pydantic model tree, executes resolve_* and post_* methods, manages DataLoader batching, and supports loader_params, context, and global configuration.
+---
+
 # Resolver API
 
 [中文版](./api_resolver.zh.md)

--- a/docs/api_resolver.zh.md
+++ b/docs/api_resolver.zh.md
@@ -1,3 +1,7 @@
+---
+description: Resolver 的 API 参考——主入口，遍历 Pydantic 模型树、执行 resolve_* 和 post_*、管理 DataLoader 批量化，支持 loader_params、context、全局配置。
+---
+
 # Resolver API
 
 [English](./api_resolver.md)

--- a/docs/api_subset.md
+++ b/docs/api_subset.md
@@ -1,3 +1,7 @@
+---
+description: API reference for DefineSubset — pick a specific field set from an entity for an API response, hide internal FK fields, while keeping ERD relationship wiring intact. Includes SubsetConfig for finer control.
+---
+
 # DefineSubset API
 
 [中文版](./api_subset.zh.md)

--- a/docs/api_subset.zh.md
+++ b/docs/api_subset.zh.md
@@ -1,3 +1,7 @@
+---
+description: DefineSubset 的 API 参考——从实体里挑出特定字段用于 API 响应，隐藏内部 FK，同时保持 ERD 关系布线。SubsetConfig 提供更细粒度的控制。
+---
+
 # DefineSubset API
 
 [English](./api_subset.md)

--- a/docs/api_use_case_mcp.md
+++ b/docs/api_use_case_mcp.md
@@ -1,3 +1,7 @@
+---
+description: API reference for create_use_case_graphql_mcp_server — expose UseCase business operations to AI agents through MCP, using the same 4-layer progressive disclosure as the ERD-driven MCP server.
+---
+
 # UseCase MCP API
 
 [中文版](./api_use_case_mcp.zh.md)

--- a/docs/api_use_case_mcp.zh.md
+++ b/docs/api_use_case_mcp.zh.md
@@ -1,3 +1,7 @@
+---
+description: create_use_case_graphql_mcp_server 的 API 参考——把 UseCase 业务操作通过 MCP 暴露给 AI Agent，复用与 ERD 驱动 MCP 服务相同的 4 层渐进式披露。
+---
+
 # UseCase MCP API
 
 [English](./api_use_case_mcp.md)

--- a/docs/architecture_entity_first.md
+++ b/docs/architecture_entity_first.md
@@ -1,3 +1,7 @@
+---
+description: Why FastAPI projects default to ORM-First and what gets lost — the missing Enterprise Business Rules layer. The case for entity-first architecture with pydantic-resolve, where Pydantic entities (not ORM models) anchor the domain.
+---
+
 # Clean Architecture for Python: The Entity-First Implementation
 
 [中文版](./architecture_entity_first.zh.md)

--- a/docs/architecture_entity_first.zh.md
+++ b/docs/architecture_entity_first.zh.md
@@ -1,3 +1,7 @@
+---
+description: 为什么 FastAPI 项目默认 ORM-First，以及丢了什么——缺失的企业业务规则层。pydantic-resolve 的实体优先架构论证：让 Pydantic 实体（而非 ORM 模型）成为领域锚点。
+---
+
 # Python 的整洁架构：Entity-First 实现
 
 [English](./architecture_entity_first.md)

--- a/docs/benchmark.md
+++ b/docs/benchmark.md
@@ -1,3 +1,7 @@
+---
+description: Benchmark report redirect — full performance comparison between pydantic-resolve and equivalent hand-written data-assembly code lives at the linked report page.
+---
+
 # Benchmark
 
 <script>

--- a/docs/blog_context_assembly_for_llm.md
+++ b/docs/blog_context_assembly_for_llm.md
@@ -1,3 +1,7 @@
+---
+description: LLM context assembly is a data assembly problem, not a prompt-engineering problem. pydantic-resolve's resolve_*, post_*, and Collector map onto three real pain points (N+1 LLM calls, cross-subtree aggregation, prompt-shape coupling) found in production AI code like open-webui.
+---
+
 # Treat the Context Window as a Data Assembly Problem: Where pydantic-resolve Fits in AI Workflows
 
 ## A typical piece of AI code

--- a/docs/blog_context_assembly_for_llm.zh.md
+++ b/docs/blog_context_assembly_for_llm.zh.md
@@ -1,3 +1,7 @@
+---
+description: LLM 上下文装配是数据装配问题，不是 prompt 工程问题。pydantic-resolve 的 resolve_*、post_*、Collector 一一对应三类真实痛点（N+1 LLM 调用、跨子树聚合、prompt 形状耦合），并以 open-webui 等生产级 AI 代码佐证。
+---
+
 # 把「上下文窗口」当作数据装配问题：pydantic-resolve 在 AI 工作流里的位置
 
 ## 一段典型的 AI 代码

--- a/docs/blog_pydantic_resolve_vs_orm.md
+++ b/docs/blog_pydantic_resolve_vs_orm.md
@@ -1,3 +1,7 @@
+---
+description: A side-by-side comparison of pydantic-resolve and SQLAlchemy ORM query patterns through three progressive nesting scenarios (single relation, multi-level tree, derived fields). Let the code speak — same ORM models, different assembly experience.
+---
+
 # Reframing the Developer Experience of Data Assembly: pydantic-resolve vs SQLAlchemy ORM Query Patterns
 
 ## Background

--- a/docs/blog_rest_graphql_and_er_diagram.md
+++ b/docs/blog_rest_graphql_and_er_diagram.md
@@ -1,3 +1,7 @@
+---
+description: The REST vs GraphQL debate misses the point — both protocols answer the same domain-model questions, just at different layers. Once relationships are centralized in an ER Diagram, the protocol choice becomes technical, not architectural.
+---
+
 # REST 和 GraphQL 之争，漏掉了关键的一层
 
 ## 一个错误的二选一

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,7 @@
+---
+description: "Release-by-release changelog for pydantic-resolve, following semver — major for breaking changes, minor for new features, patch for bug fixes. Most recent: 5.10.3."
+---
+
 # Changelog
 
 - **Major (X.0.0)**: Major new features or breaking changes

--- a/docs/core_api.md
+++ b/docs/core_api.md
@@ -1,3 +1,7 @@
+---
+description: Build a nested response tree with resolve_* methods, batched loaders, and recursive traversal. The Core API — no ERD yet, no AutoLoad yet. One query per loader regardless of tree shape.
+---
+
 # Core API
 
 [中文版](./core_api.zh.md)

--- a/docs/core_api.zh.md
+++ b/docs/core_api.zh.md
@@ -1,3 +1,7 @@
+---
+description: 用 resolve_* 方法、批量 loader、递归遍历构建嵌套响应树。Core API——还不需要 ERD，也不需要 AutoLoad。无论树的形状如何，每个 loader 只查询一次。
+---
+
 # 核心 API
 
 [English](./core_api.md)

--- a/docs/cross_layer_data_flow.md
+++ b/docs/cross_layer_data_flow.md
@@ -1,3 +1,7 @@
+---
+description: When a child needs ancestor context or a parent aggregates descendants, ExposeAs / SendTo / Collector coordinate data across the response tree without hard-coded references between classes.
+---
+
 # Cross-Layer Data Flow
 
 [中文版](./cross_layer_data_flow.zh.md)

--- a/docs/cross_layer_data_flow.zh.md
+++ b/docs/cross_layer_data_flow.zh.md
@@ -1,3 +1,7 @@
+---
+description: 子节点需要祖先上下文，或父节点要聚合后代值时，ExposeAs / SendTo / Collector 在响应树里跨层协调数据，类与类之间无需硬编码引用。
+---
+
 # 跨层数据流
 
 [English](./cross_layer_data_flow.md)

--- a/docs/dataloader_deep_dive.md
+++ b/docs/dataloader_deep_dive.md
@@ -1,3 +1,7 @@
+---
+description: How DataLoader batching works in pydantic-resolve — key collection, one batch per loader per level, result mapping. Plus patterns for caching, context-scoped loaders, and parameterized fan-out.
+---
+
 # DataLoader Deep Dive
 
 [中文版](./dataloader_deep_dive.zh.md)

--- a/docs/dataloader_deep_dive.zh.md
+++ b/docs/dataloader_deep_dive.zh.md
@@ -1,3 +1,7 @@
+---
+description: 深入 DataLoader 批量化——key 收集、每 loader 每层一次批量、结果映射。还有缓存、上下文作用域 loader、参数化 fan-out 等模式。
+---
+
 # DataLoader 深度解析
 
 [English](./dataloader_deep_dive.md)

--- a/docs/erd_and_autoload.md
+++ b/docs/erd_and_autoload.md
@@ -1,3 +1,7 @@
+---
+description: Once relationships start repeating across response models, centralize them in an ER Diagram. AutoLoad removes the need to write resolve_* at all — field names matching relationship names trigger implicit loading.
+---
+
 # ERD and AutoLoad
 
 [中文版](./erd_and_autoload.zh.md)

--- a/docs/erd_and_autoload.zh.md
+++ b/docs/erd_and_autoload.zh.md
@@ -1,3 +1,7 @@
+---
+description: 当关系在多个响应模型间重复出现，把它收敛进 ER Diagram。AutoLoad 让你完全不用写 resolve_*——字段名匹配关系名即隐式触发加载。
+---
+
 # ERD 和 AutoLoad
 
 [English](./erd_and_autoload.md)

--- a/docs/erd_define_subset.md
+++ b/docs/erd_define_subset.md
@@ -1,3 +1,7 @@
+---
+description: Hide internal FK fields like owner_id while keeping ERD relationship wiring intact. DefineSubset picks which entity fields appear in an API response, decoupling internal structure from external contract.
+---
+
 # ERD with DefineSubset
 
 [中文版](./erd_define_subset.zh.md)

--- a/docs/erd_define_subset.zh.md
+++ b/docs/erd_define_subset.zh.md
@@ -1,3 +1,7 @@
+---
+description: 在保持 ERD 关系布线完整的同时，隐藏 owner_id 这类内部 FK 字段。DefineSubset 决定哪些字段出现在 API 响应里，把内部结构与外部契约解耦。
+---
+
 # ERD 与 DefineSubset
 
 [English](./erd_define_subset.md)

--- a/docs/fastapi_integration.md
+++ b/docs/fastapi_integration.md
@@ -1,3 +1,7 @@
+---
+description: Use pydantic-resolve inside FastAPI route handlers — return resolved Pydantic models directly with relationships loaded, derived fields computed, and zero N+1. Covers async loaders, context injection, and dependency patterns.
+---
+
 # FastAPI Integration
 
 [中文版](./fastapi_integration.zh.md)

--- a/docs/fastapi_integration.zh.md
+++ b/docs/fastapi_integration.zh.md
@@ -1,3 +1,7 @@
+---
+description: 在 FastAPI 路由里直接用 pydantic-resolve——返回 resolve 好的 Pydantic 模型，关系加载完、派生字段算完、零 N+1。涵盖异步 loader、context 注入、依赖模式。
+---
+
 # FastAPI 集成
 
 [English](./fastapi_integration.md)

--- a/docs/graphql_and_mcp.md
+++ b/docs/graphql_and_mcp.md
@@ -1,3 +1,7 @@
+---
+description: GraphQL and MCP are downstream of the ERD — reuse layers over the same model graph, not alternative data-assembly systems. How they compose with Core API and each other.
+---
+
 # GraphQL and MCP
 
 [中文版](./graphql_and_mcp.zh.md) | [docs](./index.md)

--- a/docs/graphql_and_mcp.zh.md
+++ b/docs/graphql_and_mcp.zh.md
@@ -1,3 +1,7 @@
+---
+description: GraphQL 和 MCP 是 ERD 的下游复用层——基于同一份模型图，不是另一套数据装配系统。它们如何与 Core API 以及彼此组合。
+---
+
 # GraphQL and MCP
 
 [English](./graphql_and_mcp.md) | [docs](./index.zh.md)

--- a/docs/graphql_guide.md
+++ b/docs/graphql_guide.md
@@ -1,3 +1,7 @@
+---
+description: Generate a full GraphQL schema from your ERD and execute queries through GraphQLHandler. The same relationship graph that powers AutoLoad also powers GraphQL — a reuse layer, not a separate data-assembly system.
+---
+
 # GraphQL Guide
 
 [中文版](./graphql_guide.zh.md)

--- a/docs/graphql_guide.zh.md
+++ b/docs/graphql_guide.zh.md
@@ -1,3 +1,7 @@
+---
+description: 从 ERD 生成完整 GraphQL schema，通过 GraphQLHandler 执行查询。驱动 AutoLoad 的同一份关系图也驱动 GraphQL——是复用层，不是另一套数据装配系统。
+---
+
 # GraphQL 指南
 
 [English](./graphql_guide.md)

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,6 @@
 ---
 template: home.html
+description: pydantic-resolve brings Clean Architecture to Python — define business entities, declare relationships in an ER Diagram, let the framework assemble your data and eliminate N+1 as a natural byproduct. The same ERD drives REST, GraphQL, and MCP.
 ---
 
 # pydantic-resolve

--- a/docs/index.zh.md
+++ b/docs/index.zh.md
@@ -1,5 +1,6 @@
 ---
 template: home.html
+description: pydantic-resolve 把整洁架构带入 Python——定义业务实体，在 ER Diagram 里声明关系，框架自动装配数据，消除 N+1 是其自然产物。同一份 ERD 还能驱动 REST、GraphQL 与 MCP。
 ---
 
 # pydantic-resolve

--- a/docs/mcp_service.md
+++ b/docs/mcp_service.md
@@ -1,3 +1,7 @@
+---
+description: Expose your ERD as an MCP (Model Context Protocol) service so AI agents can discover and query your data through progressive disclosure — no hand-written GraphQL schema or resolvers. Translates natural-language queries into GraphQL against your ERD.
+---
+
 # MCP Service
 
 [中文版](./mcp_service.zh.md)

--- a/docs/mcp_service.zh.md
+++ b/docs/mcp_service.zh.md
@@ -1,3 +1,7 @@
+---
+description: 把 ERD 暴露为 MCP（Model Context Protocol）服务，让 AI Agent 通过渐进式披露发现并查询你的数据——无需手写 GraphQL schema 或 resolver。自然语言查询会被翻译成对 ERD 的 GraphQL 调用。
+---
+
 # MCP 服务
 
 [English](./mcp_service.md)

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -1,3 +1,7 @@
+---
+description: Migration guide across pydantic-resolve versions. Covers v5.4 → v5.5 (AutoLoad API simplification, implicit relationship resolution) and later breaking changes, with before/after code for each.
+---
+
 # Migration Guide
 
 ## v5.4 to v5.5

--- a/docs/orm_integration.md
+++ b/docs/orm_integration.md
@@ -1,3 +1,7 @@
+---
+description: When your ORM already knows the relationships, build_relationship() inspects SQLAlchemy, Django, or Tortoise ORM metadata and auto-generates Relationship definitions and DataLoader functions — no hand-written loaders needed.
+---
+
 # ORM Integration
 
 [中文版](./orm_integration.zh.md)

--- a/docs/orm_integration.zh.md
+++ b/docs/orm_integration.zh.md
@@ -1,3 +1,7 @@
+---
+description: 当 ORM 已经知道表关系，build_relationship() 直接读 SQLAlchemy、Django、Tortoise ORM 元数据，自动生成 Relationship 定义和 DataLoader 函数——无需手写 loader。
+---
+
 # ORM 集成
 
 [English](./orm_integration.md)

--- a/docs/post_processing.md
+++ b/docs/post_processing.md
@@ -1,3 +1,7 @@
+---
+description: Compute derived fields like task_count and contributor_names after the subtree is ready. post_* runs bottom-up, never re-resolves its return value, and is the natural home for counts, sums, and formatting.
+---
+
 # Post Processing
 
 [中文版](./post_processing.zh.md)

--- a/docs/post_processing.zh.md
+++ b/docs/post_processing.zh.md
@@ -1,3 +1,7 @@
+---
+description: 在子树就绪后计算派生字段，比如 task_count 和 contributor_names。post_* 自底向上执行，返回值不会再触发 resolve，是计数、求和、格式化的天然归宿。
+---
+
 # 后处理
 
 [English](./post_processing.md)

--- a/docs/pydantic_resolve_vs_orm.zh.md
+++ b/docs/pydantic_resolve_vs_orm.zh.md
@@ -1,3 +1,7 @@
+---
+description: 通过三个递进嵌套场景（单一关系、多层树、派生字段），逐行对比 pydantic-resolve 与 SQLAlchemy ORM 查询模式。让代码自己说话——同一份 ORM 模型，不同的装配体验。
+---
+
 # 重塑数据构建的开发体验：pydantic-resolve vs SQLAlchemy ORM 查询对比
 
 ## 背景

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -1,3 +1,7 @@
+---
+description: "Solve one problem fast — your data has owner_id but your API needs the full owner object, without N+1 queries. The minimal pydantic-resolve walkthrough: resolve_*, a batched loader, and Resolver()."
+---
+
 # Quick Start
 
 [中文版](./quick_start.zh.md)

--- a/docs/quick_start.zh.md
+++ b/docs/quick_start.zh.md
@@ -1,3 +1,7 @@
+---
+description: 快速解决一个问题——数据里有 owner_id，但 API 要返回完整 owner 对象，且不能 N+1。pydantic-resolve 的最小走查：resolve_*、一个批量 loader、Resolver()。
+---
+
 # 快速开始
 
 [English](./quick_start.md)

--- a/docs/reference_bridge.md
+++ b/docs/reference_bridge.md
@@ -1,3 +1,7 @@
+---
+description: Where to go after the main docs path — deeper API reference or broader project context. The hand-off page between the tutorial flow and reference material.
+---
+
 # Reference Bridge
 
 [中文版](./reference_bridge.zh.md) | [docs](./index.md)

--- a/docs/reference_bridge.zh.md
+++ b/docs/reference_bridge.zh.md
@@ -1,3 +1,7 @@
+---
+description: 主文档路径读完后去哪里——更深的 API 参考，或更广的项目背景。教程与参考资料之间的过渡页。
+---
+
 # Reference Bridge
 
 [English](./reference_bridge.md) | [docs](./index.zh.md)

--- a/docs/scenario_contract.md
+++ b/docs/scenario_contract.md
@@ -1,3 +1,7 @@
+---
+description: The canonical Sprint / Task / User scenario used across all main-path docs, so readers never have to remap concepts between pages. Defines the entities, relationships, and field names used throughout the tutorial.
+---
+
 # Scenario Contract
 
 [中文版](./scenario_contract.zh.md) | [docs](./index.md)

--- a/docs/scenario_contract.zh.md
+++ b/docs/scenario_contract.zh.md
@@ -1,3 +1,7 @@
+---
+description: 所有主路径文档共用的标准 Scenario——让读者不用在页面之间重新映射概念。定义了贯穿教程的实体、关系和字段命名。
+---
+
 # Scenario 约定
 
 [English](./scenario_contract.md) | [docs](./index.zh.md)

--- a/docs/source_mapping.md
+++ b/docs/source_mapping.md
@@ -1,3 +1,7 @@
+---
+description: How the earlier docs_old/ content was consolidated into the current docs/ structure. Reference table for tracking what moved where during the documentation reorganization.
+---
+
 # Source Mapping
 
 [中文版](./source_mapping.zh.md) | [docs](./index.md)

--- a/docs/source_mapping.zh.md
+++ b/docs/source_mapping.zh.md
@@ -1,3 +1,7 @@
+---
+description: 早期 docs_old/ 内容如何合并进当前 docs/ 结构。文档重组期间追踪"什么搬到了哪里"的参考表。
+---
+
 # 旧文档映射
 
 [English](./source_mapping.md) | [docs](./index.zh.md)

--- a/docs/use_case_mcp_service.md
+++ b/docs/use_case_mcp_service.md
@@ -1,3 +1,7 @@
+---
+description: Expose UseCase business operations to AI agents via MCP — same compose surface as the GraphQL layer, but operation-first (RPC-style) rather than entity-graph-first. Lets agents discover operations through a 4-layer progressive disclosure.
+---
+
 # UseCase MCP Service
 
 [中文版](./use_case_mcp_service.zh.md)

--- a/docs/use_case_mcp_service.zh.md
+++ b/docs/use_case_mcp_service.zh.md
@@ -1,3 +1,7 @@
+---
+description: 把 UseCase 业务操作通过 MCP 暴露给 AI Agent——与 GraphQL 层同一套 compose 接口，但按操作优先（RPC 风格）而非实体图优先。Agent 通过 4 层渐进式披露发现操作。
+---
+
 # UseCase MCP 服务
 
 [English](./use_case_mcp_service.md)

--- a/docs/voyager_guide.md
+++ b/docs/voyager_guide.md
@@ -1,3 +1,7 @@
+---
+description: Generate an interactive ERD visualization for your FastAPI app with fastapi-voyager — see how endpoints and Pydantic schemas connect without reading source files. Mounts at a single URL, reads your ERD directly.
+---
+
 # Voyager Visualization
 
 [中文版](./voyager_guide.zh.md)

--- a/docs/voyager_guide.zh.md
+++ b/docs/voyager_guide.zh.md
@@ -1,3 +1,7 @@
+---
+description: 用 fastapi-voyager 为 FastAPI 应用生成可交互的 ERD 可视化——不用翻源码就能看清 endpoint 和 schema 怎么连。挂在单个 URL，直接读你的 ERD。
+---
+
 # Voyager 可视化指南
 
 [English](./voyager_guide.md)


### PR DESCRIPTION
## Summary
- Adds a unique 1–2 sentence meta description to every page under `docs/`: 33 EN (`.md`) + 29 ZH (`.zh.md`) = 62 files.
- Replaces the site-wide default description (\"Clean Architecture for Python…\") that Google was ignoring on every page.
- Two descriptions containing `: ` (YAML mapping gotcha) are quoted; the rest are plain scalars.

## Why this matters
The previous SEO audit (#300 review) flagged that every docs page shared one generic meta description, so Google couldn't generate meaningful snippets per page. This PR fixes that — each page now has a description targeting its primary keyword, in the appropriate language.

## Verification
- [x] `uv run mkdocs build` clean (no new warnings).
- [x] All 68 built pages emit a unique `<meta name="description">` (verified by `sort | uniq -d`).
- [x] 0 pages remain on the site default.
- [x] EN and ZH versions are translated, not copied.

## Test plan
- [ ] Eyeball the rendered meta descriptions on the PR preview.
- [ ] Optionally run [Lighthouse SEO audit](https://developer.chrome.com/docs/lighthouse/seo/) on a few pages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)