### PR TITLE
fix(utils): walk MRO in get_class_field_annotations

### DIFF
--- a/pydantic_resolve/utils/types.py
+++ b/pydantic_resolve/utils/types.py
@@ -104,8 +104,12 @@ def get_core_types(tp):
 
 
 def get_class_field_annotations(cls: Type):
-    anno = cls.__dict__.get('__annotations__') or {}
-    return anno.keys()
+    annotations = {}
+    for klass in reversed(cls.__mro__):
+        own = klass.__dict__.get('__annotations__')
+        if own:
+            annotations.update(own)
+    return annotations.keys()
 
 
 def get_type(v):

--- a/tests/utils/test_types.py
+++ b/tests/utils/test_types.py
@@ -136,16 +136,30 @@ def test_get_class_field_annotations_empty():
 def test_get_class_field_annotations_with_inheritance():
     class BaseClass:
         base_field: int
-    
+
     class DerivedClass(BaseClass):
         derived_field: str
-    
-    # Should only get annotations from the specific class, not inherited ones
+
+    # Annotations are merged across the MRO so subclasses inherit
+    # their parents' annotated fields.
     base_annotations = get_class_field_annotations(BaseClass)
     derived_annotations = get_class_field_annotations(DerivedClass)
-    
+
     assert set(base_annotations) == {'base_field'}
-    assert set(derived_annotations) == {'derived_field'}
+    assert set(derived_annotations) == {'base_field', 'derived_field'}
+
+
+def test_get_class_field_annotations_subclass_with_no_own_fields():
+    # Mirrors copy_dataloader_kls: `class NewLoader(Parent): pass`
+    # must still expose the parent's annotated fields, otherwise
+    # loader param injection in _create_loader_instance breaks.
+    class Parent:
+        user_id: int
+
+    class Child(Parent):
+        pass
+
+    assert set(get_class_field_annotations(Child)) == {'user_id'}
 
 
 def test_is_optional_compatibility():

--- a/tests/utils/test_utils.py
+++ b/tests/utils/test_utils.py
@@ -24,8 +24,8 @@ def test_get_class_field_annotations():
     
     assert list(pydantic_resolve.utils.class_util.get_fields_default_value_not_provided(B)) == [('hello', True)]
     assert list(pydantic_resolve.utils.class_util.get_fields_default_value_not_provided(C)) == [('hello', False)]
-    assert list(pydantic_resolve.utils.class_util.get_fields_default_value_not_provided(D)) == []
-    assert list(pydantic_resolve.utils.class_util.get_fields_default_value_not_provided(E)) == [('world', False)]
+    assert list(pydantic_resolve.utils.class_util.get_fields_default_value_not_provided(D)) == [('hello', False)]
+    assert list(pydantic_resolve.utils.class_util.get_fields_default_value_not_provided(E)) == [('hello', False), ('world', False)]
 
 
 class User(BaseModel):
@@ -236,4 +236,31 @@ def test_copy_dataloader_kls_state_isolation():
 
     CopiedA.batch_size = 99
     assert CopiedB.batch_size == 10
+
+
+def test_copy_dataloader_kls_inherits_parent_annotations():
+    # Regression: copy_dataloader_kls creates `class NewLoader(Parent): pass`,
+    # which has no __annotations__ in its own __dict__. get_class_field_annotations
+    # must walk the MRO so the parent's loader params remain injectable on the copy.
+    from aiodataloader import DataLoader
+    from pydantic_resolve.utils.dataloader import copy_dataloader_kls
+    from pydantic_resolve.utils.types import get_class_field_annotations
+
+    class ParentLoader(DataLoader):
+        user_id: int
+        permission: str
+        async def batch_load_fn(self, keys):
+            return keys
+
+    Copied = copy_dataloader_kls('Copied', ParentLoader)
+
+    # The copy must expose the parent's annotated fields. (It will also pick up
+    # DataLoader's own annotated fields like `batch`/`cache`/`max_batch_size` —
+    # those have class-level defaults so _create_loader_instance skips them
+    # via its existing has_default branch, no behavior change there.)
+    parent_fields = {'user_id', 'permission'}
+    assert parent_fields.issubset(set(get_class_field_annotations(Copied)))
+    fields = dict(pydantic_resolve.utils.class_util.get_fields_default_value_not_provided(Copied))
+    assert fields['user_id'] is False
+    assert fields['permission'] is False
 


### PR DESCRIPTION
## Summary

- `get_class_field_annotations` previously read only `cls.__dict__['__annotations__']`, missing fields inherited from parents.
- This broke `copy_dataloader_kls`: the generated `class NewLoader(Parent): pass` has empty `__annotations__` in its own `__dict__`, so `_create_loader_instance` could not see or inject the parent's loader params (`user_id`, `permission`, etc.), raising `AttributeError` at runtime.
- Now walks `cls.__mro__` and merges annotations from every class in the chain. The same fix also corrects the `_context` detection in `analysis.py:385`, so copies of context-aware loaders are now correctly recognized.

## Why explicit MRO walk (not `cls.__annotations__.keys()`)

Python's attribute lookup returns the *first* `__annotations__` found in the MRO. So:

```python
class Parent: user_id: int
class Mixin(Parent): extra: str
Mixin.__annotations__  # {'extra': str} — loses user_id
```

The explicit reversed-MRO loop merges across all levels, which is what loader param injection needs.

## Side-effect check: DataLoader's own annotated fields

Walking the full MRO also surfaces `aiodataloader.DataLoader`'s own annotations (`batch`, `cache`, `max_batch_size`). These all have class-level defaults, so `_create_loader_instance` skips them via its existing `has_default and field not in param_config` branch — no behavior change.

## Test plan

- [x] Updated `test_get_class_field_annotations_with_inheritance` — derived class now includes base field
- [x] Updated `test_get_class_field_annotations` (test_utils.py) — `D(C)` and `E(C)` now reflect inherited `hello`
- [x] Added `test_get_class_field_annotations_subclass_with_no_own_fields` — covers `class Child(Parent): pass`
- [x] Added `test_copy_dataloader_kls_inherits_parent_annotations` — regression for the reported bug
- [x] Full suite: 707 passed, 1 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)