### PR TITLE
fix(demo): revive graphql demo for grouped layout + add to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,11 @@
 name: Test
 
-on: 
+on:
   push:
     paths:
       - 'pydantic_resolve/**'
       - 'tests/**'
+      - 'demo/**'
 
 jobs:
   test:
@@ -29,4 +30,4 @@ jobs:
         run: uv pip install "pydantic==2.11.7"
 
       - name: Test with pytest
-        run: uv run pytest tests/
+        run: uv run pytest tests/ demo/

--- a/demo/graphql/README.md
+++ b/demo/graphql/README.md
@@ -164,12 +164,14 @@ async def graphql_endpoint(req: GraphQLRequest):
 
 ## 查询示例
 
+> 查询按实体分组：`{ Entity { method(args) { fields } } }`，结果嵌套为 `data[Entity][method]`。
+
 ### 1. 获取所有用户
 
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ userEntityV3UsersV3 { id name email role created_at } }"}'
+  -d '{"query": "{ UserEntity { users_v3 { id name email role created_at } } }"}'
 ```
 
 ### 2. 获取分页用户
@@ -177,7 +179,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ userEntityV3UsersV3(limit: 2, offset: 1) { id name email } }"}'
+  -d '{"query": "{ UserEntity { users_v3(limit: 2, offset: 1) { id name email } } }"}'
 ```
 
 ### 3. 获取单个用户及其文章（嵌套查询）
@@ -185,7 +187,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ userEntityV3UserV3(id: 1) { id name email posts { title content status } } }"}'
+  -d '{"query": "{ UserEntity { user_v3(id: 1) { id name email posts { title content status } } } }"}'
 ```
 
 ### 4. 获取所有文章
@@ -193,7 +195,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ postEntityV3PostsV3 { id title content status created_at } }"}'
+  -d '{"query": "{ PostEntity { posts_v3 { id title content status created_at } } }"}'
 ```
 
 ### 5. 按状态筛选文章
@@ -201,7 +203,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ postEntityV3PostsV3(status: \"published\") { id title content } }"}'
+  -d '{"query": "{ PostEntity { posts_v3(status: \"published\") { id title content } } }"}'
 ```
 
 ### 6. 获取文章及作者（多层级嵌套）
@@ -209,7 +211,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ postEntityV3PostsV3 { title content author { name email role } } }"}'
+  -d '{"query": "{ PostEntity { posts_v3 { title content author { name email role } } } }"}'
 ```
 
 ### 7. 获取评论及作者和文章（三层嵌套）
@@ -217,7 +219,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ commentEntityV3CommentsV3 { text author { name email } post { title author { name } } } }"}'
+  -d '{"query": "{ CommentEntity { comments_v3 { text author { name email } post { title author { name } } } } }"}'
 ```
 
 ### 8. 获取单个文章及评论
@@ -225,7 +227,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ postEntityV3PostV3(id: 1) { title content author { name email } comments { text author { name } } } }"}'
+  -d '{"query": "{ PostEntity { post_v3(id: 1) { title content author { name email } comments { text author { name } } } } }"}'
 ```
 
 ### 9. 多查询
@@ -233,7 +235,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ postEntityV3PostsV3 { id title } userEntityV3UsersV3 { id name } }"}'
+  -d '{"query": "{ PostEntity { posts_v3 { id title } } UserEntity { users_v3 { id name } } }"}'
 ```
 
 ## Mutation 示例
@@ -243,7 +245,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "mutation { userEntityV3CreateUserV3(name: \"Eve\", email: \"eve@example.com\") { id name email } }"}'
+  -d '{"query": "mutation { UserEntity { createUserV3(name: \"Eve\", email: \"eve@example.com\") { id name email } } }"}'
 ```
 
 ### 使用 Input Type 创建用户
@@ -251,7 +253,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "mutation { userEntityV3CreateUserWithInputV3(input: { name: \"Frank\", email: \"frank@example.com\", role: USER }) { id name email role } }"}'
+  -d '{"query": "mutation { UserEntity { createUserWithInputV3(input: { name: \"Frank\", email: \"frank@example.com\", role: USER }) { id name email role } } }"}'
 ```
 
 ### 创建文章
@@ -259,7 +261,7 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "mutation { postEntityV3CreatePostV3(title: \"New Post\", content: \"Hello\", author_id: 1) { id title status } }"}'
+  -d '{"query": "mutation { PostEntity { createPostV3(title: \"New Post\", content: \"Hello\", author_id: 1) { id title status } } }"}'
 ```
 
 ### 创建评论
@@ -267,19 +269,19 @@ curl -X POST http://localhost:8000/graphql \
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "mutation { commentEntityV3CreateCommentV3(text: \"Nice!\", author_id: 2, post_id: 1) { id text } }"}'
+  -d '{"query": "mutation { CommentEntity { createCommentV3(text: \"Nice!\", author_id: 2, post_id: 1) { id text } } }"}'
 ```
 
 ## 数据模型
 
-### UserEntityV3
+### UserEntity
 - `id`: Int
 - `name`: String
 - `email`: String
 - `role`: String (admin/user)
 - `created_at`: DateTime
 
-### PostEntityV3
+### PostEntity
 - `id`: Int
 - `title`: String
 - `content`: String
@@ -287,7 +289,7 @@ curl -X POST http://localhost:8000/graphql \
 - `status`: String (published/draft/archived)
 - `created_at`: DateTime
 
-### CommentEntityV3
+### CommentEntity
 - `id`: Int
 - `text`: String
 - `author_id`: Int (FK → User)
@@ -296,23 +298,27 @@ curl -X POST http://localhost:8000/graphql \
 
 ## 可用查询
 
+每个查询挂在对应实体的 `{Entity}Query` 组下（如 `UserEntity.users_v3`）。
+
 | 查询 | 参数 | 返回类型 | 说明 |
 |------|------|----------|------|
-| `userEntityV3UsersV3` | `limit: Int, offset: Int` | [User] | 获取用户列表（分页） |
-| `userEntityV3UserV3` | `id: Int!` | User | 获取单个用户 |
-| `postEntityV3PostsV3` | `limit: Int, status: String` | [Post] | 获取文章列表（可按状态筛选） |
-| `postEntityV3PostV3` | `id: Int!` | Post | 获取单个文章 |
-| `commentEntityV3CommentsV3` | - | [Comment] | 获取所有评论 |
+| `UserEntity.users_v3` | `limit: Int, offset: Int` | [User] | 获取用户列表（分页） |
+| `UserEntity.user_v3` | `id: Int!` | User | 获取单个用户 |
+| `PostEntity.posts_v3` | `limit: Int, status: String` | [Post] | 获取文章列表（可按状态筛选） |
+| `PostEntity.post_v3` | `id: Int!` | Post | 获取单个文章 |
+| `CommentEntity.comments_v3` | - | [Comment] | 获取所有评论 |
 
 ## 可用变更
 
+每个变更挂在对应实体的 `{Entity}Mutation` 组下。
+
 | 变更 | 参数 | 返回类型 | 说明 |
 |------|------|----------|------|
-| `userEntityV3CreateUserV3` | `name, email, role?` | User | 创建用户 |
-| `userEntityV3CreateUserWithInputV3` | `input: CreateUserInput` | User | 使用 Input Type 创建用户 |
-| `postEntityV3CreatePostV3` | `title, content, author_id, status?` | Post | 创建文章 |
-| `postEntityV3CreatePostWithInputV3` | `input: CreatePostInput` | Post | 使用 Input Type 创建文章 |
-| `commentEntityV3CreateCommentV3` | `text, author_id, post_id` | Comment | 创建评论 |
+| `UserEntity.createUserV3` | `name, email, role?` | User | 创建用户 |
+| `UserEntity.createUserWithInputV3` | `input: CreateUserInput` | User | 使用 Input Type 创建用户 |
+| `PostEntity.createPostV3` | `title, content, author_id, status?` | Post | 创建文章 |
+| `PostEntity.createPostWithInputV3` | `input: CreatePostInput` | Post | 使用 Input Type 创建文章 |
+| `CommentEntity.createCommentV3` | `text, author_id, post_id` | Comment | 创建评论 |
 
 ## MCP Server
 

--- a/demo/graphql/START.md
+++ b/demo/graphql/START.md
@@ -26,28 +26,28 @@ https://lucasconstantino.github.io/graphiql-online/
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ users { id name email role } }"}'
+  -d '{"query": "{ UserEntity { users_v3 { id name email role } } }"}'
 ```
 
 ### 获取单个用户
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ user(id: 1) { id name email } }"}'
+  -d '{"query": "{ UserEntity { user_v3(id: 1) { id name email } } }"}'
 ```
 
 ### 获取所有文章
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ posts { id title content } }"}'
+  -d '{"query": "{ PostEntity { posts_v3 { id title content } } }"}'
 ```
 
 ### 嵌套查询 - 文章及作者
 ```bash
 curl -X POST http://localhost:8000/graphql \
   -H "Content-Type: application/json" \
-  -d '{"query": "{ posts { title author { name email } } }"}'
+  -d '{"query": "{ PostEntity { posts_v3 { title author { name email } } } }"}'
 ```
 
 ## 4. 查看文档

--- a/demo/graphql/app.py
+++ b/demo/graphql/app.py
@@ -3,6 +3,8 @@ GraphQL Demo FastAPI 应用
 提供可查询的 GraphQL endpoint
 """
 
+from contextlib import asynccontextmanager
+
 from fastapi import FastAPI, APIRouter, Request
 from fastapi.responses import PlainTextResponse, HTMLResponse
 from fastapi.middleware.cors import CORSMiddleware
@@ -15,11 +17,23 @@ from demo.graphql.entities_v3 import diagram_v3, init_db_v3
 
 diagram = diagram_v3
 
+# 配置全局 resolver
+config_global_resolver(diagram)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    """Initialize database tables and seed data on startup."""
+    await init_db_v3()
+    yield
+
+
 # 创建 FastAPI 应用
-app = FastAPI(diagram=diagram,
+app = FastAPI(
+    lifespan=lifespan,
     title="Pydantic Resolve GraphQL Demo",
     description="演示 pydantic-resolve 的 GraphQL 查询功能",
-    version="1.0.0"
+    version="1.0.0",
 )
 
 # 添加 CORS 中间件
@@ -30,15 +44,6 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-
-# 配置全局 resolver
-config_global_resolver(diagram)
-
-
-@app.on_event("startup")
-async def startup():
-    """Initialize database tables and seed data."""
-    await init_db_v3()
 
 # 创建 GraphQL handler 和 schema builder
 handler = GraphQLHandler(diagram, enable_from_attribute_in_type_adapter=True, enable_pagination=True)

--- a/demo/graphql/entities.py
+++ b/demo/graphql/entities.py
@@ -124,7 +124,7 @@ class UserEntity(BaseModel, BaseEntity):
     name: str = Field(description="用户姓名")
     email: str = Field(description="用户邮箱地址")
     role: UserRole = Field(description="用户角色")
-    created_at: datetime = Field(description="创建时间")
+    created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
     something: dict = Field(default={'key': 'value'}, description="额外信息字典")
     meta: list[UserMetaEntity] = Field(default_factory=list, description="用户元信息列表")
 
@@ -222,7 +222,7 @@ class PostEntity(BaseModel, BaseEntity):
     content: str = Field(default="", description="文章内容")
     author_id: int = Field(description="作者用户ID")
     status: PostStatus = Field(description="文章状态")
-    created_at: datetime = Field(description="创建时间")
+    created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
 
     @query
     async def get_all(cls, limit: int = 10, status: Optional[PostStatus] = None) -> List['PostEntity']:
@@ -333,7 +333,7 @@ class CommentEntity(BaseModel, BaseEntity):
     text: str = Field(description="评论内容")
     author_id: int = Field(description="评论者用户ID")
     post_id: int = Field(description="被评论的文章ID")
-    created_at: datetime = Field(description="创建时间")
+    created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
 
     @query
     async def get_all(cls) -> List['CommentEntity']:

--- a/demo/graphql/entities_v2.py
+++ b/demo/graphql/entities_v2.py
@@ -77,7 +77,7 @@ class CommentEntityV2(BaseModel):
     text: str = Field(description="评论内容")
     author_id: int = Field(description="评论者用户ID")
     post_id: int = Field(description="被评论的文章ID")
-    created_at: datetime = Field(description="创建时间")
+    created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
 
 
 class PostEntityV2(BaseModel):
@@ -90,7 +90,7 @@ class PostEntityV2(BaseModel):
     content: str = Field(default="", description="文章内容")
     author_id: int = Field(description="作者用户ID")
     status: PostStatus = Field(description="文章状态")
-    created_at: datetime = Field(description="创建时间")
+    created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
 
 
 class UserEntityV2(BaseModel):
@@ -102,7 +102,7 @@ class UserEntityV2(BaseModel):
     name: str = Field(description="用户姓名")
     email: str = Field(description="用户邮箱地址")
     role: UserRole = Field(description="用户角色")
-    created_at: datetime = Field(description="创建时间")
+    created_at: datetime = Field(default_factory=datetime.now, description="创建时间")
 
 
 # =====================================

--- a/demo/graphql/mcp_server_with_context.py
+++ b/demo/graphql/mcp_server_with_context.py
@@ -16,12 +16,12 @@ Usage:
     #    curl -X POST http://localhost:8000/mcp/ \
     #      -H "Authorization: Bearer 1" \
     #      -H "Content-Type: application/json" \
-    #      -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"graphql_query","arguments":{"query":"{ postEntityV3MyPostsV3 { id title } }","app_name":"blog_v3"}},"id":1}'
+    #      -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"graphql_query","arguments":{"query":"{ PostEntity { my_posts_v3 { id title } } }","app_name":"blog_v3"}},"id":1}'
 
     # 2. Get all posts (no context needed):
     #    curl -X POST http://localhost:8000/mcp/ \
     #      -H "Content-Type: application/json" \
-    #      -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"graphql_query","arguments":{"query":"{ postEntityV3PostsV3 { id title } }","app_name":"blog_v3"}},"id":2}'
+    #      -d '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"graphql_query","arguments":{"query":"{ PostEntity { posts_v3 { id title } } }","app_name":"blog_v3"}},"id":2}'
 
 Flow:
     HTTP Request (Authorization: Bearer <user_id>)
@@ -67,7 +67,7 @@ apps: list[AppConfig] = [
         er_diagram=diagram_v3,
         description="Blog system with context-aware queries. "
                     "Use Authorization: Bearer <user_id> header to authenticate. "
-                    "The myPostsV3 query returns only the authenticated user's posts.",
+                    "The my_posts_v3 query returns only the authenticated user's posts.",
         enable_from_attribute_in_type_adapter=True,
         context_extractor=extract_user_context,
     ),

--- a/demo/graphql/test_demo.py
+++ b/demo/graphql/test_demo.py
@@ -1,91 +1,66 @@
 """
-测试 GraphQL Demo 功能
+Smoke test for the GraphQL demo.
+
+The demo server (``demo/graphql/app.py``) serves the ``entities_v3`` schema,
+so these queries use the grouped layout (``{ Entity { method {} } }``) against
+``diagram_v3``. Runs representative queries and asserts they return data with
+no errors.
 """
 
-import asyncio
-import json
-from demo.graphql.app import BaseEntity
+import pytest
+
+from demo.graphql.entities_v3 import diagram_v3, init_db_v3
 from pydantic_resolve import config_global_resolver
 from pydantic_resolve.graphql import GraphQLHandler
 
 
-async def run_queries():
-    """测试各种 GraphQL 查询"""
+@pytest.fixture
+async def handler():
+    await init_db_v3()
+    config_global_resolver(diagram_v3)
+    return GraphQLHandler(diagram_v3, enable_from_attribute_in_type_adapter=True)
 
-    # 配置全局 resolver
-    config_global_resolver(BaseEntity.get_diagram())
 
-    # 创建 GraphQL handler
-    handler = GraphQLHandler(BaseEntity.get_diagram())
+@pytest.mark.asyncio
+async def test_demo_queries(handler):
+    """Representative grouped queries against the v3 demo schema."""
+    cases = [
+        ("all users", "{ UserEntity { users_v3 { id name email role } } }"),
+        ("paginated users", "{ UserEntity { users_v3(limit: 2, offset: 1) { id name email } } }"),
+        ("user by id", "{ UserEntity { user_v3(id: 1) { id name email role } } }"),
+        ("user with posts", "{ UserEntity { user_v3(id: 1) { id name posts { title status } } } }"),
+        ("all posts", "{ PostEntity { posts_v3 { id title content status } } }"),
+        ("published posts", '{ PostEntity { posts_v3(status: "published") { id title status } } }'),
+        ("post with author", "{ PostEntity { posts_v3 { title author { name email } } } }"),
+        ("comments", "{ CommentEntity { comments_v3 { text author { name } post { title } } } }"),
+        ("single post", "{ PostEntity { post_v3(id: 1) { title author { name } comments { text } } } }"),
+    ]
+    for name, query in cases:
+        result = await handler.execute(query)
+        assert result["errors"] is None, f"{name} failed: {result['errors']}"
+        assert result["data"] is not None, f"{name} returned no data"
 
-    print("=" * 60)
-    print("GraphQL Demo 查询测试")
-    print("=" * 60)
 
-    # 测试 1: 获取所有用户
-    print("\n1. 获取所有用户:")
-    result = await handler.execute("{ users { id name email role } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 2: 获取分页用户
-    print("\n2. 获取分页用户 (limit=2, offset=1):")
-    result = await handler.execute("{ users(limit: 2, offset: 1) { id name email } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 3: 获取单个用户
-    print("\n3. 获取单个用户 (id=1):")
-    result = await handler.execute("{ user(id: 1) { id name email role } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 4: 获取用户及其文章
-    print("\n4. 获取用户及其文章:")
-    result = await handler.execute("{ user(id: 1) { id name email posts { title content status } } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 5: 获取所有文章
-    print("\n5. 获取所有文章:")
-    result = await handler.execute("{ posts { id title content status } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 6: 获取已发布的文章
-    print("\n6. 获取已发布的文章:")
-    result = await handler.execute('{ posts(status: "published") { id title content } }')
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 7: 获取文章及其作者
-    print("\n7. 获取文章及其作者:")
-    result = await handler.execute("{ posts { title content author { name email role } } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 8: 获取评论及作者和文章
-    print("\n8. 获取评论及作者和文章:")
-    result = await handler.execute("{ comments { text author { name email } post { title } } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 9: 获取管理员
-    print("\n9. 获取所有管理员:")
-    result = await handler.execute("{ admins { id name email } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 10: 获取单个文章及完整信息
-    print("\n10. 获取单个文章及完整信息:")
-    result = await handler.execute("{ post(id: 1) { title content author { name email } comments { text author { name } } } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 11: 查询错误的 ID
-    print("\n11. 查询不存在的用户 (错误处理):")
-    result = await handler.execute("{ user(id: 999) { id name } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    # 测试 12: 无效查询
-    print("\n12. 无效查询 (错误处理):")
-    result = await handler.execute("{ non_existent { id } }")
-    print(json.dumps(result, indent=2, ensure_ascii=False))
-
-    print("\n" + "=" * 60)
-    print("测试完成！")
-    print("=" * 60)
+@pytest.mark.asyncio
+async def test_demo_unknown_field_error(handler):
+    """An unknown root group returns a clear error."""
+    result = await handler.execute("{ NonExistent { id } }")
+    assert result["errors"] is not None
 
 
 if __name__ == "__main__":
-    asyncio.run(run_queries())
+    import asyncio
+    import json
+
+    async def run():
+        await init_db_v3()
+        config_global_resolver(diagram_v3)
+        h = GraphQLHandler(diagram_v3, enable_from_attribute_in_type_adapter=True)
+        for label, query in [
+            ("users", "{ UserEntity { users_v3 { id name email role } } }"),
+            ("posts", "{ PostEntity { posts_v3 { id title content status } } }"),
+        ]:
+            print(f"\n== {label} ==")
+            print(json.dumps(await h.execute(query), indent=2, ensure_ascii=False))
+
+    asyncio.run(run())

--- a/demo/graphql/test_entities_v2.py
+++ b/demo/graphql/test_entities_v2.py
@@ -39,23 +39,23 @@ class TestQueryRecognition:
 
     def test_users_v2_query_exists(self, handler):
         """验证 users_v2 查询被识别"""
-        assert 'users_v2' in handler.query_map
+        assert 'users_v2' in handler.query_map['UserEntityV2']
 
     def test_user_v2_query_exists(self, handler):
         """验证 user_v2 查询被识别"""
-        assert 'user_v2' in handler.query_map
+        assert 'user_v2' in handler.query_map['UserEntityV2']
 
     def test_posts_v2_query_exists(self, handler):
         """验证 posts_v2 查询被识别"""
-        assert 'posts_v2' in handler.query_map
+        assert 'posts_v2' in handler.query_map['PostEntityV2']
 
     def test_post_v2_query_exists(self, handler):
         """验证 post_v2 查询被识别"""
-        assert 'post_v2' in handler.query_map
+        assert 'post_v2' in handler.query_map['PostEntityV2']
 
     def test_comments_v2_query_exists(self, handler):
         """验证 comments_v2 查询被识别"""
-        assert 'comments_v2' in handler.query_map
+        assert 'comments_v2' in handler.query_map['CommentEntityV2']
 
 
 class TestMutationRecognition:
@@ -68,15 +68,15 @@ class TestMutationRecognition:
 
     def test_create_user_v2_mutation_exists(self, handler):
         """验证 createUserV2 变更被识别"""
-        assert 'createUserV2' in handler.mutation_map
+        assert 'createUserV2' in handler.mutation_map['UserEntityV2']
 
     def test_create_post_v2_mutation_exists(self, handler):
         """验证 createPostV2 变更被识别"""
-        assert 'createPostV2' in handler.mutation_map
+        assert 'createPostV2' in handler.mutation_map['PostEntityV2']
 
     def test_create_comment_v2_mutation_exists(self, handler):
         """验证 createCommentV2 变更被识别"""
-        assert 'createCommentV2' in handler.mutation_map
+        assert 'createCommentV2' in handler.mutation_map['CommentEntityV2']
 
 
 class TestQueryExecution:
@@ -85,48 +85,48 @@ class TestQueryExecution:
     @pytest.mark.asyncio
     async def test_query_users(self, handler):
         """测试获取所有用户"""
-        result = await handler.execute('{ users_v2 { id name email role } }')
+        result = await handler.execute('{ UserEntityV2 { users_v2 { id name email role } } }')
 
         assert result['data'] is not None
-        assert 'users_v2' in result['data']
-        assert len(result['data']['users_v2']) > 0
-        assert result['data']['users_v2'][0]['name'] is not None
+        assert 'users_v2' in result['data']['UserEntityV2']
+        assert len(result['data']['UserEntityV2']['users_v2']) > 0
+        assert result['data']['UserEntityV2']['users_v2'][0]['name'] is not None
 
     @pytest.mark.asyncio
     async def test_query_user_by_id(self, handler):
         """测试根据 ID 获取单个用户"""
-        result = await handler.execute('{ user_v2(id: 1) { id name email role } }')
+        result = await handler.execute('{ UserEntityV2 { user_v2(id: 1) { id name email role } } }')
 
         assert result['data'] is not None
-        assert result['data']['user_v2']['id'] == 1
-        assert result['data']['user_v2']['name'] == 'Alice'
+        assert result['data']['UserEntityV2']['user_v2']['id'] == 1
+        assert result['data']['UserEntityV2']['user_v2']['name'] == 'Alice'
 
     @pytest.mark.asyncio
     async def test_query_posts(self, handler):
         """测试获取所有文章"""
-        result = await handler.execute('{ posts_v2 { id title content status } }')
+        result = await handler.execute('{ PostEntityV2 { posts_v2 { id title content status } } }')
 
         assert result['data'] is not None
-        assert 'posts_v2' in result['data']
-        assert len(result['data']['posts_v2']) > 0
+        assert 'posts_v2' in result['data']['PostEntityV2']
+        assert len(result['data']['PostEntityV2']['posts_v2']) > 0
 
     @pytest.mark.asyncio
     async def test_query_posts_with_filter(self, handler):
         """测试按状态筛选文章"""
-        result = await handler.execute('{ posts_v2(status: "published") { id title status } }')
+        result = await handler.execute('{ PostEntityV2 { posts_v2(status: "published") { id title status } } }')
 
         assert result['data'] is not None
-        for post in result['data']['posts_v2']:
-            assert post['status'] == 'published'
+        for post in result['data']['PostEntityV2']['posts_v2']:
+            assert post['status'] == 'PUBLISHED'
 
     @pytest.mark.asyncio
     async def test_query_comments(self, handler):
         """测试获取所有评论"""
-        result = await handler.execute('{ comments_v2 { id text } }')
+        result = await handler.execute('{ CommentEntityV2 { comments_v2 { id text } } }')
 
         assert result['data'] is not None
-        assert 'comments_v2' in result['data']
-        assert len(result['data']['comments_v2']) > 0
+        assert 'comments_v2' in result['data']['CommentEntityV2']
+        assert len(result['data']['CommentEntityV2']['comments_v2']) > 0
 
 
 class TestMutationExecution:
@@ -136,47 +136,47 @@ class TestMutationExecution:
     async def test_mutation_create_user(self, handler):
         """测试创建用户"""
         result = await handler.execute(
-            'mutation { createUserV2(name: "TestUser", email: "test@test.com") { id name email role } }'
+            'mutation { UserEntityV2 { createUserV2(name: "TestUser", email: "test@test.com") { id name email role } } }'
         )
 
         assert result['data'] is not None
-        assert result['data']['createUserV2']['name'] == 'TestUser'
-        assert result['data']['createUserV2']['email'] == 'test@test.com'
-        assert result['data']['createUserV2']['role'] == 'user'  # 默认值
+        assert result['data']['UserEntityV2']['createUserV2']['name'] == 'TestUser'
+        assert result['data']['UserEntityV2']['createUserV2']['email'] == 'test@test.com'
+        assert result['data']['UserEntityV2']['createUserV2']['role'] == 'USER'  # 默认值
 
     @pytest.mark.asyncio
     async def test_mutation_create_user_with_role(self, handler):
         """测试创建带角色的用户"""
         result = await handler.execute(
-            'mutation { createUserV2(name: "Admin", email: "admin@test.com", role: "admin") { id name role } }'
+            'mutation { UserEntityV2 { createUserV2(name: "Admin", email: "admin@test.com", role: "admin") { id name role } } }'
         )
 
         assert result['data'] is not None
-        assert result['data']['createUserV2']['role'] == 'admin'
+        assert result['data']['UserEntityV2']['createUserV2']['role'] == 'ADMIN'
 
     @pytest.mark.asyncio
     async def test_mutation_create_post(self, handler):
         """测试创建文章"""
         result = await handler.execute(
-            'mutation { createPostV2(title: "New Post", content: "Content", author_id: 1) { id title content author_id status } }'
+            'mutation { PostEntityV2 { createPostV2(title: "New Post", content: "Content", author_id: 1) { id title content author_id status } } }'
         )
 
         assert result['data'] is not None
-        assert result['data']['createPostV2']['title'] == 'New Post'
-        assert result['data']['createPostV2']['author_id'] == 1
-        assert result['data']['createPostV2']['status'] == 'draft'  # 默认值
+        assert result['data']['PostEntityV2']['createPostV2']['title'] == 'New Post'
+        assert result['data']['PostEntityV2']['createPostV2']['author_id'] == 1
+        assert result['data']['PostEntityV2']['createPostV2']['status'] == 'DRAFT'  # 默认值
 
     @pytest.mark.asyncio
     async def test_mutation_create_comment(self, handler):
         """测试创建评论"""
         result = await handler.execute(
-            'mutation { createCommentV2(text: "Nice article!", author_id: 1, post_id: 1) { id text author_id post_id } }'
+            'mutation { CommentEntityV2 { createCommentV2(text: "Nice article!", author_id: 1, post_id: 1) { id text author_id post_id } } }'
         )
 
         assert result['data'] is not None
-        assert result['data']['createCommentV2']['text'] == 'Nice article!'
-        assert result['data']['createCommentV2']['author_id'] == 1
-        assert result['data']['createCommentV2']['post_id'] == 1
+        assert result['data']['CommentEntityV2']['createCommentV2']['text'] == 'Nice article!'
+        assert result['data']['CommentEntityV2']['createCommentV2']['author_id'] == 1
+        assert result['data']['CommentEntityV2']['createCommentV2']['post_id'] == 1
 
 
 class TestRelationshipResolution:
@@ -186,11 +186,11 @@ class TestRelationshipResolution:
     async def test_post_author_relationship(self, handler):
         """测试文章-作者关系解析"""
         result = await handler.execute(
-            '{ posts_v2 { title author { name email } } }'
+            '{ PostEntityV2 { posts_v2 { title author { name email } } } }'
         )
 
         assert result['data'] is not None
-        posts = result['data']['posts_v2']
+        posts = result['data']['PostEntityV2']['posts_v2']
         assert len(posts) > 0
 
         # 验证每篇文章都有作者信息
@@ -204,11 +204,11 @@ class TestRelationshipResolution:
     async def test_post_comments_relationship(self, handler):
         """测试文章-评论关系解析"""
         result = await handler.execute(
-            '{ posts_v2 { title comments { text } } }'
+            '{ PostEntityV2 { posts_v2 { title comments { text } } } }'
         )
 
         assert result['data'] is not None
-        posts = result['data']['posts_v2']
+        posts = result['data']['PostEntityV2']['posts_v2']
         assert len(posts) > 0
 
         # 第一篇文章应该有评论
@@ -221,11 +221,11 @@ class TestRelationshipResolution:
     async def test_comment_author_relationship(self, handler):
         """测试评论-作者关系解析"""
         result = await handler.execute(
-            '{ comments_v2 { text author { name } } }'
+            '{ CommentEntityV2 { comments_v2 { text author { name } } } }'
         )
 
         assert result['data'] is not None
-        comments = result['data']['comments_v2']
+        comments = result['data']['CommentEntityV2']['comments_v2']
         assert len(comments) > 0
 
         for comment in comments:
@@ -237,11 +237,11 @@ class TestRelationshipResolution:
     async def test_comment_post_relationship(self, handler):
         """测试评论-文章关系解析"""
         result = await handler.execute(
-            '{ comments_v2 { text post { title } } }'
+            '{ CommentEntityV2 { comments_v2 { text post { title } } } }'
         )
 
         assert result['data'] is not None
-        comments = result['data']['comments_v2']
+        comments = result['data']['CommentEntityV2']['comments_v2']
         assert len(comments) > 0
 
         for comment in comments:
@@ -253,11 +253,11 @@ class TestRelationshipResolution:
     async def test_user_myposts_relationship(self, handler):
         """测试用户-文章关系解析"""
         result = await handler.execute(
-            '{ users_v2 { name myposts { title status } } }'
+            '{ UserEntityV2 { users_v2 { name myposts { title status } } } }'
         )
 
         assert result['data'] is not None
-        users = result['data']['users_v2']
+        users = result['data']['UserEntityV2']['users_v2']
         assert len(users) > 0
 
         # Alice (id=1) 应该有文章
@@ -270,11 +270,11 @@ class TestRelationshipResolution:
     async def test_nested_relationships(self, handler):
         """测试嵌套关系解析：文章 -> 作者 -> 文章列表"""
         result = await handler.execute(
-            '{ posts_v2(limit: 2) { title author { name email myposts { title } } } }'
+            '{ PostEntityV2 { posts_v2(limit: 2) { title author { name email myposts { title } } } } }'
         )
 
         assert result['data'] is not None
-        posts = result['data']['posts_v2']
+        posts = result['data']['PostEntityV2']['posts_v2']
         assert len(posts) > 0
 
         for post in posts:
@@ -293,23 +293,23 @@ class TestInputType:
     async def test_create_user_with_input(self, handler):
         """测试使用 Input Type 创建用户"""
         result = await handler.execute(
-            'mutation { createUserWithInputV2(input: {name: "InputUser", email: "input@test.com", role: "user"}) { id name email role } }'
+            'mutation { UserEntityV2 { createUserWithInputV2(input: {name: "InputUser", email: "input@test.com", role: "user"}) { id name email role } } }'
         )
 
         assert result['data'] is not None
-        assert result['data']['createUserWithInputV2']['name'] == 'InputUser'
-        assert result['data']['createUserWithInputV2']['email'] == 'input@test.com'
+        assert result['data']['UserEntityV2']['createUserWithInputV2']['name'] == 'InputUser'
+        assert result['data']['UserEntityV2']['createUserWithInputV2']['email'] == 'input@test.com'
 
     @pytest.mark.asyncio
     async def test_create_post_with_input(self, handler):
         """测试使用 Input Type 创建文章"""
         result = await handler.execute(
-            'mutation { createPostWithInputV2(input: {title: "Input Post", content: "Content", author_id: 1, status: "published"}) { id title content status } }'
+            'mutation { PostEntityV2 { createPostWithInputV2(input: {title: "Input Post", content: "Content", author_id: 1, status: "published"}) { id title content status } } }'
         )
 
         assert result['data'] is not None
-        assert result['data']['createPostWithInputV2']['title'] == 'Input Post'
-        assert result['data']['createPostWithInputV2']['status'] == 'published'
+        assert result['data']['PostEntityV2']['createPostWithInputV2']['title'] == 'Input Post'
+        assert result['data']['PostEntityV2']['createPostWithInputV2']['status'] == 'PUBLISHED'
 
 
 class TestErDiagramConfiguration:
@@ -338,7 +338,7 @@ class TestErDiagramConfiguration:
         """验证 UserEntityV2 在 ErDiagram 中有正确的关係配置"""
         user_cfg = next((cfg for cfg in diagram_v2.entities if cfg.kls == UserEntityV2), None)
         assert user_cfg is not None
-        assert len(user_cfg.relationships) == 1
+        assert len(user_cfg.relationships) == 2  # myposts + self_id (scalar demo)
         assert user_cfg.relationships[0].name == 'myposts'
 
     def test_post_entity_has_relationships(self):

--- a/demo/graphql/test_entities_v3.py
+++ b/demo/graphql/test_entities_v3.py
@@ -38,19 +38,19 @@ class TestQueryRecognition:
         assert len(handler.query_map) > 0
 
     def test_users_v3_query_exists(self, handler):
-        assert "userEntityV3UsersV3" in handler.query_map
+        assert "users_v3" in handler.query_map["UserEntity"]
 
     def test_user_v3_query_exists(self, handler):
-        assert "userEntityV3UserV3" in handler.query_map
+        assert "user_v3" in handler.query_map["UserEntity"]
 
     def test_posts_v3_query_exists(self, handler):
-        assert "postEntityV3PostsV3" in handler.query_map
+        assert "posts_v3" in handler.query_map["PostEntity"]
 
     def test_post_v3_query_exists(self, handler):
-        assert "postEntityV3PostV3" in handler.query_map
+        assert "post_v3" in handler.query_map["PostEntity"]
 
     def test_comments_v3_query_exists(self, handler):
-        assert "commentEntityV3CommentsV3" in handler.query_map
+        assert "comments_v3" in handler.query_map["CommentEntity"]
 
 
 class TestMutationRecognition:
@@ -61,13 +61,13 @@ class TestMutationRecognition:
         assert len(handler.mutation_map) > 0
 
     def test_create_user_v3_mutation_exists(self, handler):
-        assert "userEntityV3CreateUserV3" in handler.mutation_map
+        assert "createUserV3" in handler.mutation_map["UserEntity"]
 
     def test_create_post_v3_mutation_exists(self, handler):
-        assert "postEntityV3CreatePostV3" in handler.mutation_map
+        assert "createPostV3" in handler.mutation_map["PostEntity"]
 
     def test_create_comment_v3_mutation_exists(self, handler):
-        assert "commentEntityV3CreateCommentV3" in handler.mutation_map
+        assert "createCommentV3" in handler.mutation_map["CommentEntity"]
 
 
 class TestQueryExecution:
@@ -76,49 +76,49 @@ class TestQueryExecution:
     @pytest.mark.asyncio
     async def test_query_users(self, handler):
         result = await handler.execute(
-            "{ userEntityV3UsersV3 { id name email role } }"
+            "{ UserEntity { users_v3 { id name email role } } }"
         )
         assert result["data"] is not None
-        users = result["data"]["userEntityV3UsersV3"]
+        users = result["data"]["UserEntity"]["users_v3"]
         assert len(users) > 0
         assert users[0]["name"] is not None
 
     @pytest.mark.asyncio
     async def test_query_user_by_id(self, handler):
         result = await handler.execute(
-            "{ userEntityV3UserV3(id: 1) { id name email role } }"
+            "{ UserEntity { user_v3(id: 1) { id name email role } } }"
         )
         assert result["data"] is not None
-        user = result["data"]["userEntityV3UserV3"]
+        user = result["data"]["UserEntity"]["user_v3"]
         assert user["id"] == 1
         assert user["name"] == "Alice"
 
     @pytest.mark.asyncio
     async def test_query_posts(self, handler):
         result = await handler.execute(
-            "{ postEntityV3PostsV3 { id title content status } }"
+            "{ PostEntity { posts_v3 { id title content status } } }"
         )
         assert result["data"] is not None
-        assert "postEntityV3PostsV3" in result["data"]
-        assert len(result["data"]["postEntityV3PostsV3"]) > 0
+        assert "posts_v3" in result["data"]["PostEntity"]
+        assert len(result["data"]["PostEntity"]["posts_v3"]) > 0
 
     @pytest.mark.asyncio
     async def test_query_posts_with_filter(self, handler):
         result = await handler.execute(
-            '{ postEntityV3PostsV3(status: "published") { id title status } }'
+            '{ PostEntity { posts_v3(status: "published") { id title status } } }'
         )
         assert result["data"] is not None
-        for post in result["data"]["postEntityV3PostsV3"]:
+        for post in result["data"]["PostEntity"]["posts_v3"]:
             assert post["status"] == "published"
 
     @pytest.mark.asyncio
     async def test_query_comments(self, handler):
         result = await handler.execute(
-            "{ commentEntityV3CommentsV3 { id text } }"
+            "{ CommentEntity { comments_v3 { id text } } }"
         )
         assert result["data"] is not None
-        assert "commentEntityV3CommentsV3" in result["data"]
-        assert len(result["data"]["commentEntityV3CommentsV3"]) > 0
+        assert "comments_v3" in result["data"]["CommentEntity"]
+        assert len(result["data"]["CommentEntity"]["comments_v3"]) > 0
 
 
 class TestMutationExecution:
@@ -127,10 +127,10 @@ class TestMutationExecution:
     @pytest.mark.asyncio
     async def test_mutation_create_user(self, handler):
         result = await handler.execute(
-            'mutation { userEntityV3CreateUserV3(name: "TestUser", email: "test@test.com") { id name email role } }'
+            'mutation { UserEntity { createUserV3(name: "TestUser", email: "test@test.com") { id name email role } } }'
         )
         assert result["data"] is not None
-        user = result["data"]["userEntityV3CreateUserV3"]
+        user = result["data"]["UserEntity"]["createUserV3"]
         assert user["name"] == "TestUser"
         assert user["email"] == "test@test.com"
         assert user["role"] == "user"
@@ -138,18 +138,18 @@ class TestMutationExecution:
     @pytest.mark.asyncio
     async def test_mutation_create_user_with_role(self, handler):
         result = await handler.execute(
-            'mutation { userEntityV3CreateUserV3(name: "Admin", email: "admin@test.com", role: "admin") { id name role } }'
+            'mutation { UserEntity { createUserV3(name: "Admin", email: "admin@test.com", role: "admin") { id name role } } }'
         )
         assert result["data"] is not None
-        assert result["data"]["userEntityV3CreateUserV3"]["role"] == "admin"
+        assert result["data"]["UserEntity"]["createUserV3"]["role"] == "admin"
 
     @pytest.mark.asyncio
     async def test_mutation_create_post(self, handler):
         result = await handler.execute(
-            'mutation { postEntityV3CreatePostV3(title: "New Post", content: "Content", author_id: 1) { id title content author_id status } }'
+            'mutation { PostEntity { createPostV3(title: "New Post", content: "Content", author_id: 1) { id title content author_id status } } }'
         )
         assert result["data"] is not None
-        post = result["data"]["postEntityV3CreatePostV3"]
+        post = result["data"]["PostEntity"]["createPostV3"]
         assert post["title"] == "New Post"
         assert post["author_id"] == 1
         assert post["status"] == "draft"
@@ -157,10 +157,10 @@ class TestMutationExecution:
     @pytest.mark.asyncio
     async def test_mutation_create_comment(self, handler):
         result = await handler.execute(
-            'mutation { commentEntityV3CreateCommentV3(text: "Nice article!", author_id: 1, post_id: 1) { id text author_id post_id } }'
+            'mutation { CommentEntity { createCommentV3(text: "Nice article!", author_id: 1, post_id: 1) { id text author_id post_id } } }'
         )
         assert result["data"] is not None
-        comment = result["data"]["commentEntityV3CreateCommentV3"]
+        comment = result["data"]["CommentEntity"]["createCommentV3"]
         assert comment["text"] == "Nice article!"
         assert comment["author_id"] == 1
         assert comment["post_id"] == 1
@@ -172,10 +172,10 @@ class TestRelationshipResolution:
     @pytest.mark.asyncio
     async def test_post_author_relationship(self, handler):
         result = await handler.execute(
-            "{ postEntityV3PostsV3 { title author { name email } } }"
+            "{ PostEntity { posts_v3 { title author { name email } } } }"
         )
         assert result["data"] is not None
-        posts = result["data"]["postEntityV3PostsV3"]
+        posts = result["data"]["PostEntity"]["posts_v3"]
         assert len(posts) > 0
         for post in posts:
             assert "author" in post
@@ -186,10 +186,10 @@ class TestRelationshipResolution:
     @pytest.mark.asyncio
     async def test_post_comments_relationship(self, handler):
         result = await handler.execute(
-            "{ postEntityV3PostsV3 { title comments { text } } }"
+            "{ PostEntity { posts_v3 { title comments { text } } } }"
         )
         assert result["data"] is not None
-        posts = result["data"]["postEntityV3PostsV3"]
+        posts = result["data"]["PostEntity"]["posts_v3"]
         assert len(posts) > 0
         first_post = posts[0]
         if first_post.get("comments"):
@@ -199,10 +199,10 @@ class TestRelationshipResolution:
     @pytest.mark.asyncio
     async def test_comment_author_relationship(self, handler):
         result = await handler.execute(
-            "{ commentEntityV3CommentsV3 { text author { name } } }"
+            "{ CommentEntity { comments_v3 { text author { name } } } }"
         )
         assert result["data"] is not None
-        comments = result["data"]["commentEntityV3CommentsV3"]
+        comments = result["data"]["CommentEntity"]["comments_v3"]
         assert len(comments) > 0
         for comment in comments:
             assert "author" in comment
@@ -212,10 +212,10 @@ class TestRelationshipResolution:
     @pytest.mark.asyncio
     async def test_comment_post_relationship(self, handler):
         result = await handler.execute(
-            "{ commentEntityV3CommentsV3 { text post { title } } }"
+            "{ CommentEntity { comments_v3 { text post { title } } } }"
         )
         assert result["data"] is not None
-        comments = result["data"]["commentEntityV3CommentsV3"]
+        comments = result["data"]["CommentEntity"]["comments_v3"]
         assert len(comments) > 0
         for comment in comments:
             assert "post" in comment
@@ -226,10 +226,10 @@ class TestRelationshipResolution:
     async def test_user_posts_relationship(self, handler):
         """Test user -> posts relationship (renamed from myposts in v2)."""
         result = await handler.execute(
-            "{ userEntityV3UsersV3 { name posts { title status } } }"
+            "{ UserEntity { users_v3 { name posts { title status } } } }"
         )
         assert result["data"] is not None
-        users = result["data"]["userEntityV3UsersV3"]
+        users = result["data"]["UserEntity"]["users_v3"]
         assert len(users) > 0
         alice = next((u for u in users if u["name"] == "Alice"), None)
         if alice and alice.get("posts"):
@@ -240,20 +240,20 @@ class TestRelationshipResolution:
     async def test_user_comments_relationship(self, handler):
         """Test user -> comments relationship (new in v3 via ORM)."""
         result = await handler.execute(
-            "{ userEntityV3UsersV3 { name comments { text } } }"
+            "{ UserEntity { users_v3 { name comments { text } } } }"
         )
         assert result["data"] is not None
-        users = result["data"]["userEntityV3UsersV3"]
+        users = result["data"]["UserEntity"]["users_v3"]
         assert len(users) > 0
 
     @pytest.mark.asyncio
     async def test_nested_relationships(self, handler):
         """Test nested resolution: Post -> Author -> Posts."""
         result = await handler.execute(
-            "{ postEntityV3PostsV3(limit: 2) { title author { name email posts { title } } } }"
+            "{ PostEntity { posts_v3(limit: 2) { title author { name email posts { title } } } } }"
         )
         assert result["data"] is not None
-        posts = result["data"]["postEntityV3PostsV3"]
+        posts = result["data"]["PostEntity"]["posts_v3"]
         assert len(posts) > 0
         for post in posts:
             assert "author" in post
@@ -269,20 +269,20 @@ class TestInputType:
     @pytest.mark.asyncio
     async def test_create_user_with_input(self, handler):
         result = await handler.execute(
-            'mutation { userEntityV3CreateUserWithInputV3(input: {name: "InputUser", email: "input@test.com", role: "user"}) { id name email role } }'
+            'mutation { UserEntity { createUserWithInputV3(input: {name: "InputUser", email: "input@test.com", role: "user"}) { id name email role } } }'
         )
         assert result["data"] is not None
-        user = result["data"]["userEntityV3CreateUserWithInputV3"]
+        user = result["data"]["UserEntity"]["createUserWithInputV3"]
         assert user["name"] == "InputUser"
         assert user["email"] == "input@test.com"
 
     @pytest.mark.asyncio
     async def test_create_post_with_input(self, handler):
         result = await handler.execute(
-            'mutation { postEntityV3CreatePostWithInputV3(input: {title: "Input Post", content: "Content", author_id: 1, status: "published"}) { id title content status } }'
+            'mutation { PostEntity { createPostWithInputV3(input: {title: "Input Post", content: "Content", author_id: 1, status: "published"}) { id title content status } } }'
         )
         assert result["data"] is not None
-        post = result["data"]["postEntityV3CreatePostWithInputV3"]
+        post = result["data"]["PostEntity"]["createPostWithInputV3"]
         assert post["title"] == "Input Post"
         assert post["status"] == "published"
 
@@ -295,15 +295,15 @@ class TestErDiagramConfiguration:
 
     def test_diagram_contains_user_entity(self):
         entity_names = [cfg.kls.__name__ for cfg in diagram_v3.entities]
-        assert "UserEntityV3" in entity_names
+        assert "UserEntity" in entity_names
 
     def test_diagram_contains_post_entity(self):
         entity_names = [cfg.kls.__name__ for cfg in diagram_v3.entities]
-        assert "PostEntityV3" in entity_names
+        assert "PostEntity" in entity_names
 
     def test_diagram_contains_comment_entity(self):
         entity_names = [cfg.kls.__name__ for cfg in diagram_v3.entities]
-        assert "CommentEntityV3" in entity_names
+        assert "CommentEntity" in entity_names
 
     def test_user_entity_has_relationships(self):
         user_cfg = next(
@@ -329,12 +329,12 @@ class TestContextInjection:
     async def test_context_reaches_query_method(self, handler):
         """Context dict is passed to @query method's context parameter."""
         result = await handler.execute(
-            "{ postEntityV3MyPostsV3 { id title author_id } }",
+            "{ PostEntity { my_posts_v3 { id title author_id } } }",
             context={"user_id": 1},
         )
         assert result["errors"] is None
         assert result["data"] is not None
-        posts = result["data"]["postEntityV3MyPostsV3"]
+        posts = result["data"]["PostEntity"]["my_posts_v3"]
         # All posts should belong to user_id=1 (Alice)
         for post in posts:
             assert post["author_id"] == 1
@@ -343,12 +343,12 @@ class TestContextInjection:
     async def test_context_with_different_user(self, handler):
         """Different context values produce different results."""
         result = await handler.execute(
-            "{ postEntityV3MyPostsV3 { id title author_id } }",
+            "{ PostEntity { my_posts_v3 { id title author_id } } }",
             context={"user_id": 2},
         )
         assert result["errors"] is None
         assert result["data"] is not None
-        posts = result["data"]["postEntityV3MyPostsV3"]
+        posts = result["data"]["PostEntity"]["my_posts_v3"]
         for post in posts:
             assert post["author_id"] == 2
 
@@ -356,7 +356,7 @@ class TestContextInjection:
     async def test_context_none_raises_for_required_query(self, handler):
         """Method that requires context raises when context is not provided."""
         result = await handler.execute(
-            "{ postEntityV3MyPostsV3 { id title } }",
+            "{ PostEntity { my_posts_v3 { id title } } }",
         )
         # Should have errors because the method raises ValueError
         assert result["errors"] is not None
@@ -365,13 +365,13 @@ class TestContextInjection:
     async def test_query_without_context_unaffected(self, handler):
         """Queries that don't use context still work normally."""
         result = await handler.execute(
-            "{ postEntityV3PostsV3 { id title } }",
+            "{ PostEntity { posts_v3 { id title } } }",
             context={"user_id": 999},
         )
         assert result["errors"] is None
         assert result["data"] is not None
         # Should return ALL posts, not filtered by user_id
-        assert len(result["data"]["postEntityV3PostsV3"]) > 0
+        assert len(result["data"]["PostEntity"]["posts_v3"]) > 0
 
     @pytest.mark.asyncio
     async def test_context_hidden_from_schema(self):
@@ -380,8 +380,8 @@ class TestContextInjection:
         builder = SchemaBuilder(d)
         schema_sdl = builder.build_schema()
 
-        # The MyPostsV3 query should exist but without _context param
-        assert "MyPostsV3" in schema_sdl
+        # The my_posts_v3 query should exist but without _context param
+        assert "my_posts_v3" in schema_sdl
         # _context should NOT appear as a parameter in the schema
         assert "_context" not in schema_sdl
 

--- a/demo/graphql/test_mutations.py
+++ b/demo/graphql/test_mutations.py
@@ -1,54 +1,51 @@
 """
-快速测试所有的 Mutations
+快速测试 entities.py (v1) 的 Mutations —— 分组布局
+
+每个 mutation 现在挂在 ``{Entity}Mutation`` 组下：
+``mutation { UserEntity { create_user(...) {...} } }``
 """
 
-import asyncio
+import pytest
+
 from demo.graphql.entities import BaseEntity
+from pydantic_resolve import config_global_resolver
 from pydantic_resolve.graphql import GraphQLHandler
 
 
-async def test_all_mutations():
-    """快速测试所有 10 个 mutations"""
-    handler = GraphQLHandler(BaseEntity.get_diagram())
+@pytest.fixture
+def handler():
+    config_global_resolver(BaseEntity.get_diagram())
+    return GraphQLHandler(BaseEntity.get_diagram())
 
-    print("🧪 测试所有 Mutations")
-    print("=" * 70)
 
-    tests = [
-        ("创建用户", '{ createUser(name: "Test User", email: "test@test.com", role: "user") { id name email role } }'),
-        ("更新用户", '{ updateUser(id: 1, name: "Updated") { id name } }'),
-        ("创建文章", '{ createPost(title: "Test Post", content: "Test", author_id: 1, status: "draft") { id title status } }'),
-        ("发布文章", '{ publishPost(id: 2) { id title status } }'),
-        ("创建评论", '{ createComment(text: "Test comment", author_id: 1, post_id: 1) { id text } }'),
+@pytest.mark.asyncio
+async def test_all_mutations(handler):
+    """分组布局下执行 v1 的代表性 mutations。"""
+    cases = [
+        ("创建用户", 'mutation { UserEntity { create_user(name: "Test User", email: "test@test.com", role: "user") { id name email role } } }'),
+        ("更新用户", 'mutation { UserEntity { update_user(id: 1, name: "Updated") { id name } } }'),
+        ("创建文章", 'mutation { PostEntity { create_post(title: "Test Post", content: "Test", author_id: 1, status: "draft") { id title status } } }'),
+        ("发布文章", 'mutation { PostEntity { publish_post(id: 2) { id title status } } }'),
+        ("创建评论", 'mutation { CommentEntity { create_comment(text: "Test comment", author_id: 1, post_id: 1) { id text } } }'),
     ]
 
-    passed = 0
-    failed = 0
-
-    for name, query in tests:
-        try:
-            result = await handler.execute(query)
-            if result.get("data") and not result.get("errors"):
-                print(f"✅ {name}: 成功")
-                passed += 1
-            else:
-                print(f"❌ {name}: 失败 - {result.get('errors')}")
-                failed += 1
-        except Exception as e:
-            print(f"❌ {name}: 异常 - {e}")
-            failed += 1
-
-    print("\n" + "=" * 70)
-    print(f"测试结果: {passed} 通过, {failed} 失败")
-    print("=" * 70)
-
-    # 显示统计信息
-    print("\n📊 Mutation 统计:")
-    print(f"   总 mutations: {len(handler.mutation_map)}")
-    print(f"   UserEntity: {len([m for m in handler.mutation_map if 'user' in m.lower()])}")
-    print(f"   PostEntity: {len([m for m in handler.mutation_map if 'post' in m.lower()])}")
-    print(f"   CommentEntity: {len([m for m in handler.mutation_map if 'comment' in m.lower()])}")
+    for name, query in cases:
+        result = await handler.execute(query)
+        assert result.get("data") is not None, f"{name} 失败: {result.get('errors')}"
+        assert not result.get("errors"), f"{name} 失败: {result['errors']}"
 
 
 if __name__ == "__main__":
-    asyncio.run(test_all_mutations())
+    import asyncio
+
+    async def run():
+        config_global_resolver(BaseEntity.get_diagram())
+        h = GraphQLHandler(BaseEntity.get_diagram())
+        for name, query in [
+            ("创建用户", 'mutation { UserEntity { create_user(name: "Test User", email: "test@test.com", role: "user") { id name email role } } }'),
+            ("创建文章", 'mutation { PostEntity { create_post(title: "Test Post", content: "Test", author_id: 1, status: "draft") { id title status } } }'),
+        ]:
+            result = await h.execute(query)
+            print(f"{'✅' if result.get('data') and not result.get('errors') else '❌'} {name}")
+
+    asyncio.run(run())

--- a/demo/graphql/test_queries.sh
+++ b/demo/graphql/test_queries.sh
@@ -30,30 +30,27 @@ test_query() {
 }
 
 # 测试 1: 获取所有用户
-test_query "获取所有用户" "{ users { id name email role } }"
+test_query "获取所有用户" "{ UserEntity { users_v3 { id name email role } } }"
 
 # 测试 2: 获取分页用户
-test_query "获取分页用户" "{ users(limit: 2, offset: 1) { id name email } }"
+test_query "获取分页用户" "{ UserEntity { users_v3(limit: 2, offset: 1) { id name email } } }"
 
 # 测试 3: 获取单个用户
-test_query "获取单个用户" "{ user(id: 1) { id name email role } }"
+test_query "获取单个用户" "{ UserEntity { user_v3(id: 1) { id name email role } } }"
 
-# 测试 4: 获取管理员
-test_query "获取管理员" "{ admins { id name email } }"
+# 测试 4: 获取所有文章
+test_query "获取所有文章" "{ PostEntity { posts_v3 { id title content status } } }"
 
-# 测试 5: 获取所有文章
-test_query "获取所有文章" "{ posts { id title content status } }"
+# 测试 5: 获取已发布文章
+test_query "获取已发布文章" '{ PostEntity { posts_v3(status: "published") { id title } } }'
 
-# 测试 6: 获取已发布文章
-test_query "获取已发布文章" '{ posts(status: "published") { id title } }'
+# 测试 6: 获取单个文章
+test_query "获取单个文章" "{ PostEntity { post_v3(id: 1) { id title content } } }"
 
-# 测试 7: 获取单个文章
-test_query "获取单个文章" "{ post(id: 1) { id title content } }"
+# 测试 7: 获取评论
+test_query "获取评论" "{ CommentEntity { comments_v3 { id text } } }"
 
-# 测试 8: 获取评论
-test_query "获取评论" "{ comments { id text } }"
-
-# 测试 9: 错误处理 - 未知查询
-test_query "错误处理 - 未知查询" "{ non_existent { id } }"
+# 测试 8: 错误处理 - 未知查询
+test_query "错误处理 - 未知查询" "{ NonExistent { id } }"
 
 echo -e "${GREEN}所有测试完成！${NC}"


### PR DESCRIPTION
Follow-up to #304 (v6 grouped layout). The `demo/graphql/` suite had drifted across several versions — tests used bare/flat query names that matched neither the old nor the new schema, and `test_demo.py` couldn't even be collected (FastAPI `on_event` deprecation, fatal under `filterwarnings = error`).

## What changed
- **Grouped queries everywhere**: `test_demo`, `test_mutations`, `test_entities_v2`, `test_entities_v3`, `mcp_server_with_context`, `START.md`, `test_queries.sh`, `README.md` → `{ Entity { method {} } }` with nested `data[Entity][method]` response keys.
- **Pre-existing demo bugs fixed** (uncovered while converting):
  - `created_at` was a required field but the `create_*` mutations never set it → `default_factory=datetime.now` (entities.py, entities_v2.py).
  - Enum assertions expected the Python value (`'published'`); GraphQL correctly emits the member name (`'PUBLISHED'`) → assertions updated.
  - `UserEntityV2` relationship count `1 → 2` (`myposts` + the `self_id` scalar demo).
  - `test_demo.py`'s broken `from app import BaseEntity` + missing `init_db_v3()`; rewritten as a real pytest smoke test.
- **`app.py`**: `@app.on_event("startup")` → `lifespan` (so the demo server imports/runs on modern FastAPI).
- **CI**: `demo/**` added to the path trigger and `uv run pytest tests/ demo/` so the demo can't silently rot again.

## Verification
- `demo/graphql/`: **75 passed**
- `tests/ + demo/` (the CI command): **901 passed, 1 skipped**
- `ruff check demo/graphql/`: clean

Demo-only changes — no library code, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)